### PR TITLE
Additional compatibility for mods 

### DIFF
--- a/[CP] Blue Eggs and Golden Mayo/compat/AlazdrielQuails.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/AlazdrielQuails.json
@@ -1,0 +1,88 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Alazdriel.Quails_TinyQuailMayo1",
+				"OutputItem",
+				"Alazdriel.Quails_TinyQuailMayo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Alazdriel.Quails_QuailMayo1",
+				"OutputItem",
+				"Alazdriel.Quails_QuailMayo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Alazdriel.Quails_TinyQuailMayo2",
+				"OutputItem",
+				"Alazdriel.Quails_TinyQuailMayo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Alazdriel.Quails_QuailMayo2",
+				"OutputItem",
+				"Alazdriel.Quails_QuailMayo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/HXWfreshlybaked.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/HXWfreshlybaked.json
@@ -1,0 +1,4261 @@
+{
+	"Changes": [	
+		
+	//Muffins
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_blueberry_muffins",
+				"OutputItem",
+				"HXW.FreshlyBaked_blueberry_muffins"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_rhubarb_muffins",
+				"OutputItem",
+				"HXW.FreshlyBaked_rhubarb_muffins"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_cherry_muffins",
+				"OutputItem",
+				"HXW.FreshlyBaked_cherry_muffins"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_poppyseed_muffins",
+				"OutputItem",
+				"HXW.FreshlyBaked_poppyseed_muffins"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_maple_muffins",
+				"OutputItem",
+				"HXW.FreshlyBaked_maple_muffins"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_walnut_muffins",
+				"OutputItem",
+				"HXW.FreshlyBaked_walnut_muffins"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_pistachio_muffins",
+				"OutputItem",
+				"HXW.FreshlyBaked_pistachio_muffins"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_coffee_cake_muffins",
+				"OutputItem",
+				"HXW.FreshlyBaked_coffee_cake_muffins"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+
+    //Scones    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_chocolate_scones",
+				"OutputItem",
+				"HXW.FreshlyBaked_chocolate_scones"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_raspberry_scones",
+				"OutputItem",
+				"HXW.FreshlyBaked_raspberry_scones"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_brown_sugar_scones",
+				"OutputItem",
+				"HXW.FreshlyBaked_brown_sugar_scones"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_blackberry_scones",
+				"OutputItem",
+				"HXW.FreshlyBaked_blackberry_scones"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_cranberry_scones",
+				"OutputItem",
+				"HXW.FreshlyBaked_cranberry_scones"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_lavender_scones",
+				"OutputItem",
+				"HXW.FreshlyBaked_lavender_scones"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_vanilla_scones",
+				"OutputItem",
+				"HXW.FreshlyBaked_vanilla_scones"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+
+    //Generic     
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Oven",
+				"OutputRules",
+				"HXW.FreshlyBaked_flavor_muffins",
+				"OutputItem",
+				"HXW.FreshlyBaked_flavor_muffins"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveID":"DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+
+    //Cake    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_celebration_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_celebration_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_apple_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_apple_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_citrus_thyme_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_citrus_thyme_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_raspberry_chamomile_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_raspberry_chamomile_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_peach_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_peach_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_spiced_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_spiced_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_tropical_floral_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_tropical_floral_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_almond_elderflower_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_almond_elderflower_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_victoria_sponge_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_victoria_sponge_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_pink_velvet_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_pink_velvet_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_summer_flower_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_summer_flower_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_chocolate_mudslide_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_chocolate_mudslide_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_pretty_pink_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_pretty_pink_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Cake_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_flavor_cake",
+				"OutputItem",
+				"HXW.FreshlyBaked_flavor_cake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveID":"DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+
+    //Cupcakes    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_strawberry_cupcakes",
+				"OutputItem",
+				"HXW.FreshlyBaked_strawberry_cupcakes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_vanilla_cupcakes",
+				"OutputItem",
+				"HXW.FreshlyBaked_vanilla_cupcakes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_chocolate_cupcakes",
+				"OutputItem",
+				"HXW.FreshlyBaked_chocolate_cupcakes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_neapolitan_cupcakes",
+				"OutputItem",
+				"HXW.FreshlyBaked_neapolitan_cupcakes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 6
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_matcha_cupcakes",
+				"OutputItem",
+				"HXW.FreshlyBaked_matcha_cupcakes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_chocolate_mint_cupcakes",
+				"OutputItem",
+				"HXW.FreshlyBaked_chocolate_mint_cupcakes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_tropical_cupcakes",
+				"OutputItem",
+				"HXW.FreshlyBaked_tropical_cupcakes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_flavor_cupcakes",
+				"OutputItem",
+				"HXW.FreshlyBaked_flavor_cupcakes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveID":"DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.9
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+
+    //Petit Fours    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_floral_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_floral_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_pineapple_cherry_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_pineapple_cherry_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_rose_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_rose_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_blueberry_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_blueberry_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_carrot_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_carrot_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_pink_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_pink_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_chocolate_strawberry_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_chocolate_strawberry_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_berry_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_berry_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_citrus_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_citrus_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_red_velvet_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_red_velvet_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_apple_petit_fours",
+				"OutputItem",
+				"HXW.FreshlyBaked_apple_petit_fours"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+
+    //Pie    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_brown_sugar_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_brown_sugar_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_cherry_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_cherry_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_elderberry_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_elderberry_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_apple_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_apple_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_sweet_potato_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_sweet_potato_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_pumpkin_spice_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_pumpkin_spice_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_lemon_meringue_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_lemon_meringue_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_key_lime_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_key_lime_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_coconut_cream_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_coconut_cream_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_peach_pie",
+				"OutputItem",
+				"HXW.FreshlyBaked_peach_pie"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+
+    //Tart    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_blueberry_tart",
+				"OutputItem",
+				"HXW.FreshlyBaked_blueberry_tart"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_chocolate_hazelnut_tart",
+				"OutputItem",
+				"HXW.FreshlyBaked_chocolate_hazelnut_tart"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_orange_dandelion_tart",
+				"OutputItem",
+				"HXW.FreshlyBaked_orange_dandelion_tart"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_raspberry_pistachio_tart",
+				"OutputItem",
+				"HXW.FreshlyBaked_raspberry_pistachio_tart"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_starfruit_tart",
+				"OutputItem",
+				"HXW.FreshlyBaked_starfruit_tart"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_mojito_tart",
+				"OutputItem",
+				"HXW.FreshlyBaked_mojito_tart"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_mango_pineapple_tart",
+				"OutputItem",
+				"HXW.FreshlyBaked_mango_pineapple_tart"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Pie_Station",
+				"OutputRules",
+				"HXW.FreshlyBaked_flavor_tart",
+				"OutputItem",
+				"HXW.FreshlyBaked_flavor_tart"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveID":"DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 250
+                    }
+				]
+			}
+		},
+
+    //Cookies    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_vanilla_heart_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_vanilla_heart_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_cherry_thumbprint_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_cherry_thumbprint_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_cheesecake_thumbprint_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_cheesecake_thumbprint_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_assorted_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_assorted_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_magic_thumbprint_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_magic_thumbprint_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_chocolate_thumbprint_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_chocolate_thumbprint_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_lemon_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_lemon_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_strawberry_heart_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_strawberry_heart_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_rose_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_rose_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_honey_lavender_cookies",
+				"OutputItem",
+				"HXW.FreshlyBaked_honey_lavender_cookies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+
+    //Macarons    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_floral_macarons",
+				"OutputItem",
+				"HXW.FreshlyBaked_floral_macarons"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_berry_macarons",
+				"OutputItem",
+				"HXW.FreshlyBaked_berry_macarons"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_cafe_macarons",
+				"OutputItem",
+				"HXW.FreshlyBaked_cafe_macarons"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_citrus_macarons",
+				"OutputItem",
+				"HXW.FreshlyBaked_citrus_macarons"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_chocolate_macarons",
+				"OutputItem",
+				"HXW.FreshlyBaked_chocolate_macarons"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+
+    //Brownies    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_fudgy_brownies",
+				"OutputItem",
+				"HXW.FreshlyBaked_fudgy_brownies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_mint_brownies",
+				"OutputItem",
+				"HXW.FreshlyBaked_mint_brownies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_coconut_brownies",
+				"OutputItem",
+				"HXW.FreshlyBaked_coconut_brownies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_lemon_bars",
+				"OutputItem",
+				"HXW.FreshlyBaked_lemon_bars"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_red_velvet_brownies",
+				"OutputItem",
+				"HXW.FreshlyBaked_red_velvet_brownies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Mixer",
+				"OutputRules",
+				"HXW.FreshlyBaked_red_velvet_brownies",
+				"OutputItem",
+				"HXW.FreshlyBaked_red_velvet_brownies"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+
+    //Generic
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)HXW.FreshlyBaked_Mixer",
+                "OutputRules",
+                "HXW.FreshlyBaked_fruit_cookies",
+                "OutputItem",
+                "HXW.FreshlyBaked_fruit_cookies"
+            ],
+            "Entries": {
+                "CopyQuality": true,
+                "CopyPrice": true,
+                "PreserveID":"Atelier.Cauldron_DROP_IN",
+                "PriceModifierMode": "Stack",
+                "PriceModifiers": [
+                    {
+                        "Modification": "Multiply",
+                        "Amount": 2.75
+                    },
+                    {
+                        "Id": "6480.qualitygoods",
+                        "Modification": "Multiply",
+                        "Amount": "{{Profit Scaling}}"
+                    },
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+                ]
+            }
+        },  
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)HXW.FreshlyBaked_Mixer",
+                "OutputRules",
+                "HXW.FreshlyBaked_flower_cookies",
+                "OutputItem",
+                "HXW.FreshlyBaked_flower_cookies"
+            ],
+            "Entries": {
+                "CopyQuality": true,
+                "CopyPrice": true,
+                "PreserveID":"Atelier.Cauldron_DROP_IN",
+                "PriceModifierMode": "Stack",
+                "PriceModifiers": [
+                    {
+                        "Modification": "Multiply",
+                        "Amount": 2.75
+                    },
+                    {
+                        "Id": "6480.qualitygoods",
+                        "Modification": "Multiply",
+                        "Amount": "{{Profit Scaling}}"
+                    },
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+                ]
+            }
+        },
+
+    //Bread    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_bread_loaves",
+				"OutputItem",
+				"HXW.FreshlyBaked_bread_loaves"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_baguettes",
+				"OutputItem",
+				"HXW.FreshlyBaked_baguettes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},   
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_pretzel",
+				"OutputItem",
+				"HXW.FreshlyBaked_pretzel"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		}, 
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_pretzel_buns",
+				"OutputItem",
+				"HXW.FreshlyBaked_pretzel_buns"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_rye_loaves",
+				"OutputItem",
+				"HXW.FreshlyBaked_rye_loaves"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_sandwich_buns",
+				"OutputItem",
+				"HXW.FreshlyBaked_sandwich_buns"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_poppyseed_bread",
+				"OutputItem",
+				"HXW.FreshlyBaked_poppyseed_bread"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_ciabatta",
+				"OutputItem",
+				"HXW.FreshlyBaked_ciabatta"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_iced_buns",
+				"OutputItem",
+				"HXW.FreshlyBaked_iced_buns"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_classic_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_classic_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_country_bread",
+				"OutputItem",
+				"HXW.FreshlyBaked_country_bread"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_olive_loaves",
+				"OutputItem",
+				"HXW.FreshlyBaked_olive_loaves"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_croissants",
+				"OutputItem",
+				"HXW.FreshlyBaked_croissants"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_sweet_buns",
+				"OutputItem",
+				"HXW.FreshlyBaked_sweet_buns"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_demi_baguette",
+				"OutputItem",
+				"HXW.FreshlyBaked_demi_baguette"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_brioche",
+				"OutputItem",
+				"HXW.FreshlyBaked_brioche"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_sourdough",
+				"OutputItem",
+				"HXW.FreshlyBaked_sourdough"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_herb_focaccia",
+				"OutputItem",
+				"HXW.FreshlyBaked_herb_focaccia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_tomato_basil_focaccia",
+				"OutputItem",
+				"HXW.FreshlyBaked_tomato_basil_focaccia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_pumpernickel_bread",
+				"OutputItem",
+				"HXW.FreshlyBaked_pumpernickel_bread"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_cinnamon_rolls",
+				"OutputItem",
+				"HXW.FreshlyBaked_cinnamon_rolls"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_cinnamon_rolls",
+				"OutputItem",
+				"HXW.FreshlyBaked_cinnamon_rolls"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_pain_au_chocolat",
+				"OutputItem",
+				"HXW.FreshlyBaked_pain_au_chocolat"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+
+    //Doughnuts    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_strawberry_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_strawberry_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_matcha_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_matcha_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_cinnamon_spice_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_cinnamon_spice_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_lavender_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_lavender_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_apple_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_apple_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_lemon_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_lemon_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_chocolate_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_chocolate_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_fruit_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_fruit_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveID":"Atelier.Cauldron_DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_flower_doughnuts",
+				"OutputItem",
+				"HXW.FreshlyBaked_flower_doughnuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveID":"Atelier.Cauldron_DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 150
+                    }
+				]
+			}
+		},
+
+    //Eclairs    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_vanilla_eclairs",
+				"OutputItem",
+				"HXW.FreshlyBaked_vanilla_eclairs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.6
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_raspberry_eclairs",
+				"OutputItem",
+				"HXW.FreshlyBaked_raspberry_eclairs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.6
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_pistachio_eclairs",
+				"OutputItem",
+				"HXW.FreshlyBaked_pistachio_eclairs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.6
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_blueberry_eclairs",
+				"OutputItem",
+				"HXW.FreshlyBaked_blueberry_eclairs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.6
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_mocha_eclairs",
+				"OutputItem",
+				"HXW.FreshlyBaked_mocha_eclairs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.6
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Rolling_Pin",
+				"OutputRules",
+				"HXW.FreshlyBaked_citrus_eclairs",
+				"OutputItem",
+				"HXW.FreshlyBaked_citrus_eclairs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.6
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 65
+                    }
+				]
+			}
+		},
+
+    //Pudding    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Deluxe_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_gem_pudding",
+				"OutputItem",
+				"HXW.FreshlyBaked_gem_pudding"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Deluxe_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_mystical_pudding",
+				"OutputItem",
+				"HXW.FreshlyBaked_mystical_pudding"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Deluxe_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_cherry_blossom_pudding",
+				"OutputItem",
+				"HXW.FreshlyBaked_cherry_blossom_pudding"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Deluxe_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_raspberry_pudding",
+				"OutputItem",
+				"HXW.FreshlyBaked_raspberry_pudding"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Deluxe_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_tropical_pudding",
+				"OutputItem",
+				"HXW.FreshlyBaked_tropical_pudding"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Deluxe_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_vanilla_pudding",
+				"OutputItem",
+				"HXW.FreshlyBaked_vanilla_pudding"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Deluxe_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_lemon_pudding",
+				"OutputItem",
+				"HXW.FreshlyBaked_lemon_pudding"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)HXW.FreshlyBaked_Deluxe_Dessert_Stand",
+				"OutputRules",
+				"HXW.FreshlyBaked_lemon_pudding",
+				"OutputItem",
+				"HXW.FreshlyBaked_lemon_pudding"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 200
+                    }
+				]
+			}
+		},
+
+	]
+}		

--- a/[CP] Blue Eggs and Golden Mayo/compat/Meara.Roosters.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/Meara.Roosters.json
@@ -1,0 +1,46 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Meara.Roosters_BlueMayoRules",
+				"OutputItem",
+				"(O)306"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Meara.Roosters_VoidMayoRules",
+				"OutputItem",
+				"(O)308"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/WAGbarista(cold).json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/WAGbarista(cold).json
@@ -1,0 +1,2908 @@
+{
+	"Changes": [
+
+    //Boba 
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_banana_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_banana_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_blacktea_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_blacktea_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_blueberry_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_blueberry_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_brownsugar_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_brownsugar_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_caramel_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_caramel_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_coconut_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_coconut_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_coffee_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_coffee_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_jasmine_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_jasmine_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_mango_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_mango_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_matcha_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_matcha_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_melon_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_melon_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_oolong_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_oolong_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_peach_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_peach_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_rose_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_rose_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_strawberry_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_strawberry_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_taro_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_taro_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_thai_boba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_thai_boba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_FruitBoba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_FruitBoba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PreserveID":"DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_BobaStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_FlowerBoba",
+				"OutputItem",
+				"wildflour.atelierjuicebar_FlowerBoba"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PreserveID":"DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 50
+                    }
+				]
+			}
+		},
+
+    //Juice    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_apple_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_apple_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_berry_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_berry_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_carrot_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_carrot_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_grape_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_grape_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_mix_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_mix_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_orange_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_orange_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_pomegranate_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_pomegranate_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_tropical_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_tropical_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_fruit_punch",
+				"OutputItem",
+				"wildflour.atelierjuicebar_fruit_punch"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_amber_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_amber_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_jade_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_jade_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_lapis_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_lapis_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_pearl_juice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_pearl_juice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_apricot_elixir",
+				"OutputItem",
+				"wildflour.atelierjuicebar_apricot_elixir"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_apple_elixir",
+				"OutputItem",
+				"wildflour.atelierjuicebar_apple_elixir"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_cherry_elixir",
+				"OutputItem",
+				"wildflour.atelierjuicebar_cherry_elixir"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_mango_elixir",
+				"OutputItem",
+				"wildflour.atelierjuicebar_mango_elixir"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_orange_elixir",
+				"OutputItem",
+				"wildflour.atelierjuicebar_orange_elixir"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_peach_elixir",
+				"OutputItem",
+				"wildflour.atelierjuicebar_peach_elixir"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_pomegranate_elixir",
+				"OutputItem",
+				"wildflour.atelierjuicebar_pomegranate_elixir"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_FruitJuice",
+				"OutputItem",
+				"wildflour.atelierjuicebar_FruitJuice"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PreserveID":"DROP_IN",
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }
+				]
+			}
+		},
+
+    //Iced tea    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_iced_tea",
+				"OutputItem",
+				"wildflour.atelierjuicebar_iced_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    } 
+                ]
+            }        
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_green_icedtea",
+				"OutputItem",
+				"wildflour.atelierjuicebar_green_icedtea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    } 
+                ]
+            }                 
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_pineapple_icedtea",
+				"OutputItem",
+				"wildflour.atelierjuicebar_pineapple_icedtea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    } 
+                ]
+            }                 
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_peach_icedtea",
+				"OutputItem",
+				"wildflour.atelierjuicebar_peach_icedtea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }  
+                ]
+            }                    
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_JuiceStation",
+				"OutputRules",
+				"wildflour.atelierjuicebar_thai_icedtea",
+				"OutputItem",
+				"wildflour.atelierjuicebar_thai_icedtea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 100
+                    }  
+                ]
+            }  	
+		},
+
+    //Lemonade    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_blackberry_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_blackberry_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_chamomile_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_chamomile_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_cherry_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_cherry_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_classic_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_classic_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_green_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_green_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_jasmine_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_jasmine_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_lavender_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_lavender_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_lime_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_lime_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_melon_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_melon_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_mint_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_mint_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_pomegranate_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_pomegranate_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_pink_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_pink_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_rose_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_rose_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_raspberry_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_raspberry_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_gardenia_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_gardenia_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_hibiscus_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_hibiscus_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_orangeblossom_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_orangeblossom_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_borage_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_borage_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_calendula_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_calendula_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_hollyhock_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_hollyhock_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_springpansy_lemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_springpansy_lemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_FruitLemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_FruitLemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PreserveID":"DROP_IN",
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierjuicebar_LemonadeStand",
+				"OutputRules",
+				"wildflour.atelierjuicebar_FlowerLemonade",
+				"OutputItem",
+				"wildflour.atelierjuicebar_FlowerLemonade"
+			],
+			"Entries": {         
+                "CopyQuality": true,
+                "CopyPrice": true,
+				"PreserveID":"DROP_IN",
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+						"Id": "6480.qualitygoods",
+                        "Modification": "Add",
+                        "Amount": 140
+					}
+				]
+			}
+		},
+
+    //Kombucha    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_apple_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_apple_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_vanilla_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_vanilla_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_matcha_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_matcha_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_cinnamon_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_cinnamon_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_chamomile_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_chamomile_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_breakfast_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_breakfast_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_jasmine_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_jasmine_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_ginger_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_ginger_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_grey_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_grey_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_lemon_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_lemon_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_mint_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_mint_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_berry_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_berry_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_peach_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_peach_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_pineapple_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_pineapple_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_pomegranate_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_pomegranate_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_raspberry_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_raspberry_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_rose_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_rose_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_sakura_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_sakura_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_strawberry_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_strawberry_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_gardenia_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_gardenia_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_hibiscus_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_hibiscus_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_hibiscus_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_hibiscus_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_borage_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_borage_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_calendula_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_calendula_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_hollyhock_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_hollyhock_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_springpansy_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_springpansy_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_orangeblossom_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_orangeblossom_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"wildflour.atelierjuicebar_keg_flavored_kombucha",
+				"OutputItem",
+				"wildflour.atelierjuicebar_flavored_kombucha"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PreserveID":"DROP_IN",
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.25
+                    },
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/WAGbarista(hot).json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/WAGbarista(hot).json
@@ -1,0 +1,2370 @@
+{
+	"Changes": [
+	
+    //Tea sachet
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_apple_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_apple_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_vanilla_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_vanilla_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_breakfast_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_breakfast_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_matcha_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_matcha_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_cinnamon_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_cinnamon_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_chamomile_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_chamomile_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_breakfast_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_breakfast_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_jasmine_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_jasmine_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_ginger_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_ginger_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_grey_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_grey_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_lemon_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_lemon_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_matcha_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_matcha_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_mint_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_mint_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_berry_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_berry_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_peach_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_peach_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_pineapple_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_pineapple_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_pomegranate_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_pomegranate_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_raspberry_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_raspberry_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_rose_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_rose_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_sakura_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_sakura_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_strawberry_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_strawberry_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_gardenia_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_gardenia_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_hibiscus_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_hibiscus_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_borage_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_borage_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_calendula_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_calendula_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_hollyhock_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_hollyhock_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_springpansy_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_springpansy_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_orangeblossom_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_orangeblossom_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaProcessor",
+				"OutputRules",
+				"wildflour.atelierbarista_flavored_sachet",
+				"OutputItem",
+				"wildflour.atelierbarista_flavored_sachet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveID":"DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+      
+    //Tea    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_apple_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_apple_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_vanilla_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_vanilla_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_matcha_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_matcha_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_cinnamon_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_cinnamon_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_chamomile_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_chamomile_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_breakfast_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_breakfast_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_jasmine_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_jasmine_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_ginger_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_ginger_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_grey_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_grey_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_lemon_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_lemon_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_mint_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_mint_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_berry_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_berry_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_peach_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_peach_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_pineapple_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_pineapple_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_pomegranate_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_pomegranate_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_raspberry_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_raspberry_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_rose_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_rose_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_sakura_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_sakura_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_strawberry_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_strawberry_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_gardenia_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_gardenia_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_hibiscus_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_hibiscus_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_borage_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_borage_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_calendula_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_calendula_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_hollyhock_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_hollyhock_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_springpansy_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_springpansy_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_orangeblossom_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_orangeblossom_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},  
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_TeaKettle",
+				"OutputRules",
+				"wildflour.atelierbarista_flavored_tea",
+				"OutputItem",
+				"wildflour.atelierbarista_flavored_tea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveID":"Atelier.Cauldron_DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+       
+    //Coffee ground    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_breakfast_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_breakfast_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_vanilla_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_vanilla_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_cold_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_cold_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_donut_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_donut_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_hazelnut_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_hazelnut_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_holiday_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_holiday_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_mocha_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_mocha_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_pumpkin_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_pumpkin_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_sweetheart_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_sweetheart_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeGrinder",
+				"OutputRules",
+				"wildflour.atelierbarista_coconut_ground",
+				"OutputItem",
+				"wildflour.atelierbarista_coconut_ground"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.4
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 45
+					}
+				]
+			}
+		},
+
+    //Coffee    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_breakfast_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_breakfast_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_vanilla_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_vanilla_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_cold_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_cold_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_donut_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_donut_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_hazelnut_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_hazelnut_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_holiday_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_holiday_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_mocha_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_mocha_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_pumpkin_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_pumpkin_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_sweetheart_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_sweetheart_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierbarista_CoffeeBrewer",
+				"OutputRules",
+				"wildflour.atelierbarista_coconut_latte",
+				"OutputItem",
+				"wildflour.atelierbarista_coconut_latte"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 100
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/WAGbrewer.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/WAGbrewer.json
@@ -1,0 +1,3205 @@
+{
+	"Changes": [
+	
+    //Ale    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_ancient_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_ancient_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_apple_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_apple_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_apricot_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_apricot_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_banana_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_banana_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_blackberry_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_blackberry_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_blueberry_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_blueberry_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_cactus_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_cactus_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_cherry_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_cherry_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_coconut_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_coconut_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_cranberry_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_cranberry_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_crystal_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_crystal_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_gem_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_gem_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_mango_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_mango_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_melon_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_melon_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_orange_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_orange_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_peach_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_peach_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_pineapple_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_pineapple_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_plum_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_plum_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_pomegranate_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_pomegranate_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_pumpkin_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_pumpkin_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_spiced_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_spiced_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_starfruit_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_starfruit_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_strawberry_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_strawberry_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_vanilla_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_vanilla_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_lemon_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_lemon_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_lime_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_lime_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_wild_raspberry_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_wild_raspberry_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_wild_strawberry_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_wild_strawberry_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_dragonfruit_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_dragonfruit_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_fig_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_fig_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_grapefruit_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_grapefruit_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_lychee_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_lychee_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_papaya_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_papaya_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_pear_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_pear_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_persimmon_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_persimmon_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_pomelo_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_pomelo_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_ambrosia_apple_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_ambrosia_apple_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_moongold_apricot_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_moongold_apricot_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_ladyfinger_banana_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_ladyfinger_banana_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_sour_cherry_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_sour_cherry_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_sunset_mango_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_sunset_mango_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_blood_orange_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_blood_orange_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_snow_peach_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_snow_peach_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_pomegranate_ale",
+				"OutputItem",
+				"wildflour.alesxmeads_pomegranate_ale"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.alesxmeads_AleKeg",
+				"OutputRules",
+				"wildflour.alesxmeads_FruitAle",
+				"OutputItem",
+				"wildflour.alesxmeads_FruitAle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PreserveId": "DROP_IN",
+                "PriceModifierMode": "Stack", 
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 70
+                    }
+				]
+			}
+		},
+
+    //Mead
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_ancient_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_ancient_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_plum_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_plum_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_apricot_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_apricot_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_banana_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_banana_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_pineapple_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_pineapple_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_blackberry_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_blackberry_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_blueberry_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_blueberry_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_cactus_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_cactus_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_apple_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_apple_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_crystal_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_crystal_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_gem_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_gem_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_mango_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_mango_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_orange_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_orange_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_peach_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_peach_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_spiced_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_spiced_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_starfruit_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_starfruit_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_strawberry_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_strawberry_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_melon_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_melon_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_cherry_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_cherry_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_pomegranate_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_pomegranate_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_cranberry_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_cranberry_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_coconut_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_coconut_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_salmonberry_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_salmonberry_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_vanilla_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_vanilla_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_chamomile_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_chamomile_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_petite_lime_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_petite_lime_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_lavender_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_lavender_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_petite_lemon_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_petite_lemon_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_mallow_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_mallow_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_sakura_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_sakura_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_cinnamon_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_cinnamon_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_wild_raspberry_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_wild_raspberry_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_wild_strawberry_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_wild_strawberry_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_ambrosia_apple_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_ambrosia_apple_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_moongold_apricot_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_moongold_apricot_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_ladyfinger_banana_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_ladyfinger_banana_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_sour_cherry_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_sour_cherry_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_sunset_mango_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_sunset_mango_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_blood_orange_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_blood_orange_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_snow_peach_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_snow_peach_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_eversweet_pomegranate_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_eversweet_pomegranate_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_grapefruit_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_grapefruit_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_pear_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_pear_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_dragonfruit_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_dragonfruit_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_lychee_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_lychee_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_persimmon_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_persimmon_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_papaya_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_papaya_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_pomelo_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_pomelo_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_fig_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_fig_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_gardenia_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_gardenia_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_hibiscus_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_hibiscus_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_borage_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_borage_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_calendula_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_calendula_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_hollyhock_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_hollyhock_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_springpansy_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_springpansy_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_orangeblossom_mead",
+                "OutputItem",
+                "wildflour.alesxmeads_orangeblossom_mead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_FruitMead",
+                "OutputItem",
+                "wildflour.alesxmeads_FruitMead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PreserveId": "DROP_IN",
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+        {
+            "Action": "EditData",
+            "Target": "Data/Machines",
+            "TargetField": [
+                "(BC)wildflour.alesxmeads_MeadKeg",
+                "OutputRules",
+                "wildflour.alesxmeads_FlowerMead",
+                "OutputItem",
+                "wildflour.alesxmeads_FlowerMead"
+            ],
+            "Entries": {
+            "CopyQuality": true,
+            "CopyPrice": true,
+            "PreserveId": "DROP_IN",
+            "PriceModifierMode": "Stack", 
+            "PriceModifiers": [
+                {
+                    "Modification": "Multiply",
+                    "Amount": 3
+                },
+                {
+                    "Id": "6480.qualitygoods",
+                    "Modification": "Multiply",
+                    "Amount": "{{Profit Scaling}}"
+                },
+                {
+                    "Modification": "Add",
+                    "Amount": 100
+                    }
+                ]   
+            }
+        },
+	]
+
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/WAGflorist.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/WAGflorist.json
@@ -1,0 +1,4848 @@
+{
+	"Changes": [	
+		
+	//Bouquet
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_jazz_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_jazz_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_vanilla_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_vanilla_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_fairy_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_fairy_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_chamomile_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_chamomile_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_lavender_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_lavender_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_jasmine_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_jasmine_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_mallow_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_mallow_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_poppy_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_poppy_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sakura_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_sakura_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_spangle_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_spangle_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sunflower_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_sunflower_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_tulip_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_tulip_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sweetpea_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_sweetpea_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_gardenia_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_gardenia_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_hibiscus_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_hibiscus_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_freesia_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_freesia_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_peony_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_peony_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_snapdragon_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_snapdragon_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_calendula_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_calendula_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_hollyhock_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_hollyhock_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_springpansy_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_springpansy_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_cornflower_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_cornflower_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_iris_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_iris_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_pinkmorningglory_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_pinkmorningglory_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_primrose_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_primrose_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_cosmos_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_cosmos_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_pixiebell_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_pixiebell_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FlowerStation",
+				"OutputRules",
+				"wildflour.atelierfloral_flower_bouquet",
+				"OutputItem",
+				"wildflour.atelierfloral_flower_bouquet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+    //Perfume    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_jazz_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_jazz_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_fairy_rose_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_fairy_rose_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_poppy_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_poppy_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_spangle_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_spangle_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sunflower_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_sunflower_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_tulip_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_tulip_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_chamomile_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_chamomile_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_jasmine_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_jasmine_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_lavender_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_lavender_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_mallow_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_mallow_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sakura_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_sakura_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_vanilla_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_vanilla_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_gardenia_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_gardenia_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_hibiscus_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_hibiscus_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_freesia_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_freesia_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_peony_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_peony_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_snapdragon_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_snapdragon_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_calendula_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_calendula_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_hollyhock_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_hollyhock_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_springpansy_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_springpansy_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_cornflower_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_cornflower_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_iris_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_iris_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_pinkmorningglory_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_pinkmorningglory_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_primrose_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_primrose_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_cosmos_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_cosmos_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_pixiebell_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_pixiebell_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sweetpea_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_sweetpea_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_flower_perfume",
+				"OutputItem",
+				"wildflour.atelierfloral_flower_perfume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+    //Incense    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_autumn_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_autumn_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_chiffon_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_chiffon_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_chamomile_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_chamomile_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_daisy_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_daisy_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_violet_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_violet_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_jasmine_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_jasmine_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_lavender_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_lavender_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_lily_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_lily_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_lily_incense_dusk",
+				"OutputItem",
+				"wildflour.atelierfloral_lily_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_mugwort_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_mugwort_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_pixie_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_pixie_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_primrose_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_primrose_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_mysteria_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_mysteria_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_spring_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_spring_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_summer_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_summer_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_thistle_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_thistle_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_valerian_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_valerian_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_vanilla_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_vanilla_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_winter_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_winter_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_yarrow_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_yarrow_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_FragranceStation",
+				"OutputRules",
+				"wildflour.atelierfloral_flower_incense",
+				"OutputItem",
+				"wildflour.atelierfloral_flower_incense"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveId": "Atelier.Cauldron_DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+    //Candles    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_jazz_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_jazz_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_vanilla_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_vanilla_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_fairy_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_fairy_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_chamomile_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_chamomile_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_lavender_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_lavender_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_jasmine_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_jasmine_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_mallow_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_mallow_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_poppy_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_poppy_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sakura_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_sakura_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_spangle_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_spangle_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sunflower_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_sunflower_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_tulip_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_tulip_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sweetpea_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_sweetpea_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_crocus_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_crocus_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_thistle_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_thistle_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_valerian_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_valerian_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_yarrow_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_yarrow_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_violet_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_violet_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_daisy_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_daisy_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_gardenia_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_gardenia_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_hibiscus_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_hibiscus_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_freesia_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_freesia_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_peony_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_peony_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_snapdragon_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_snapdragon_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_calendula_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_calendula_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_hollyhock_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_hollyhock_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_springpansy_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_springpansy_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_cornflower_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_cornflower_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_iris_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_iris_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_pinkmorningglory_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_pinkmorningglory_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_primrose_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_primrose_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_cosmos_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_cosmos_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_pixiebell_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_pixiebell_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_flower_candles",
+				"OutputItem",
+				"wildflour.atelierfloral_flower_candles"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveId": "Atelier.Cauldron_DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+
+    //Soap    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_jazz_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_jazz_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_vanilla_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_vanilla_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_fairy_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_fairy_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_chamomile_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_chamomile_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_lavender_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_lavender_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_jasmine_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_jasmine_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_mallow_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_mallow_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_poppy_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_poppy_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sakura_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_sakura_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_spangle_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_spangle_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sunflower_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_sunflower_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_sweetpea_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_sweetpea_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_tulip_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_tulip_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_gardenia_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_gardenia_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_hibiscus_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_hibiscus_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_freesia_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_freesia_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_peony_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_peony_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_snapdragon_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_snapdragon_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_calendula_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_calendula_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_hollyhock_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_hollyhock_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_springpansy_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_springpansy_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_cornflower_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_cornflower_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_iris_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_iris_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfloral_CandleStation",
+				"OutputRules",
+				"wildflour.atelierfloral_flower_soap",
+				"OutputItem",
+				"wildflour.atelierfloral_flower_soap"
+			],
+            "When":{"HasMod |contains=wildflour.honeybees": true},
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 80
+                    }
+				]
+			}
+		},
+
+    //Dried Flower    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_chamomile",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_chamomile"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_crocus",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_crocus"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_daisy",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_daisy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_fairy_rose",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_fairy_rose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_jasmine",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_jasmine"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_jazz",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_jazz"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_lavender",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_lavender"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_mallow",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_mallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_violet",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_violet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_mugwort",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_mugwort"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_mysteria",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_mysteria"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_poppy",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_poppy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_quartz_primrose",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_quartz_primrose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_sakura",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_sakura"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_spangle",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_spangle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_sunflower",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_sunflower"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_thistle",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_thistle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_tulip",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_tulip"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_valerian",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_valerian"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_vanilla",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_vanilla"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_yarrow",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_yarrow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_sweetpea",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_sweetpea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_gardenia",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_gardenia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_hibiscus",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_hibiscus"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_freesia",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_freesia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_peony",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_peony"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_snapdragon",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_snapdragon"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_calendula",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_calendula"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_hollyhock",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_hollyhock"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_springpansy",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_springpansy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_cornflower",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_cornflower"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_iris",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_iris"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"wildflour.atelierfloral_Dehydrator_dried_flowers",
+				"OutputItem",
+				"wildflour.atelierfloral_dried_flowers"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+                "PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 5.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}		

--- a/[CP] Blue Eggs and Golden Mayo/compat/WAGfrozengoods.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/WAGfrozengoods.json
@@ -1,0 +1,3054 @@
+{
+	"Changes": [
+		
+    //Popsicles    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_ancient_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_ancient_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_blueberry_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_blueberry_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_cherry_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_cherry_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_coconut_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_coconut_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_grape_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_grape_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_lemon_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_lemon_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_lime_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_lime_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_gem_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_gem_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_mango_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_mango_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_melon_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_melon_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_orange_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_orange_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_peach_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_peach_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_pineapple_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_pineapple_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_strawberry_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_strawberry_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_raspberry_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_raspberry_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_wildberry_popsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_wildberry_popsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_FruitPopsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_FruitPopsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PreserveId": "DROP_IN",
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_BlastChiller",
+				"OutputRules",
+				"wildflour.atelierfrozen_FlowerPopsicle",
+				"OutputItem",
+				"wildflour.atelierfrozen_FlowerPopsicle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PreserveId": "DROP_IN",
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 1.75
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+    
+    //Icecream cone    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_ancient_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_ancient_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_apple_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_apple_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_cherrynut_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_cherrynut_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_cherryblossom_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_cherryblossom_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_chocolate_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_chocolate_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_coconut_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_coconut_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_coffee_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_coffee_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_cookie_dough_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_cookie_dough_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_cookie_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_cookie_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_horchata_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_horchata_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_lavender_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_lavender_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_maple_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_maple_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_mint_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_mint_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_pistachio_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_pistachio_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_strawberry_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_strawberry_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_vanilla_cone",
+				"OutputItem",
+				"wildflour.atelierfrozen_vanilla_cone"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2.5
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+
+    //Froyo    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_cake_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_cake_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_blueberry_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_blueberry_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_cheesecake_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_cheesecake_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_cherrychoco_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_cherrychoco_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_choco_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_choco_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_lemon_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_lemon_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_mango_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_mango_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_orange_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_orange_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_pumpkin_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_pumpkin_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_starfruit_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_starfruit_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_gem_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_gem_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_wildberry_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_wildberry_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_caramel_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_caramel_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_creamsicle_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_creamsicle_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_custard_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_custard_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_candy_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_candy_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_tiramisu_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_tiramisu_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_macaron_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_macaron_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_galaxy_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_galaxy_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_pie_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_pie_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_shortcake_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_shortcake_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_cotton_candy_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_cotton_candy_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_ancient_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_ancient_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_coffee_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_coffee_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_peach_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_peach_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_pineapple_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_pineapple_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_vanilla_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_vanilla_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_plain_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_plain_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_mint_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_mint_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_lime_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_lime_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_raspberry_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_raspberry_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_raspberry_froyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_raspberry_froyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_FruitIceCream",
+				"OutputItem",
+				"wildflour.atelierfrozen_FruitIceCream"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+                "PreserveId": "DROP_IN",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_FlowerIceCream",
+				"OutputItem",
+				"wildflour.atelierfrozen_FlowerIceCream"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+                "PreserveId": "DROP_IN",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_FruitFroyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_FruitFroyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+                "PreserveId": "DROP_IN",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.atelierfrozen_TreatMaker",
+				"OutputRules",
+				"wildflour.atelierfrozen_FlowerFroyo",
+				"OutputItem",
+				"wildflour.atelierfrozen_FlowerFroyo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+                "PreserveId": "DROP_IN",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 2
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+                    {
+                        "Modification": "Add",
+                        "Amount": 60
+                    }
+				]
+			}
+		},
+
+    //Milkshakes    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_choco_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_choco_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_candy_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_candy_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_orange_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_orange_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_earlgrey_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_earlgrey_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_lime_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_lime_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_colada_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_colada_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_pumpkin_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_pumpkin_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_strawberry_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_strawberry_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_vanilla_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_vanilla_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_caramel_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_caramel_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_ancient_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_ancient_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_apple_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_apple_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_apricot_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_apricot_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_banana_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_banana_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_blueberry_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_blueberry_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_cherry_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_cherry_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_rose_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_rose_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_matcha_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_matcha_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_mango_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_mango_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_peach_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_peach_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_pomegranate_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_pomegranate_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_gem_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_gem_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_chai_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_chai_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_sakura_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_sakura_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_cinnamon_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_cinnamon_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_elderberry_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_elderberry_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_marshmallow_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_marshmallow_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_mint_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_mint_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_lemon_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_lemon_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_raspberry_milkshake",
+				"OutputItem",
+				"wildflour.atelierfrozen_raspberry_milkshake"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_FruitMilkshake",
+				"OutputItem",
+				"CAULDRON_CUSTOM_PRESERVE wildflour.atelierfrozen_FruitMilkshake DROP_IN_PRESERVE"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PreserveId": "Atelier.Cauldron_DROP_IN",
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.atelierfrozen_KitchenBlender_FlowerMilkshake",
+				"OutputItem",
+				"CAULDRON_CUSTOM_PRESERVE wildflour.atelierfrozen_FlowerMilkshake DROP_IN_PRESERVE"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+                "PreserveId": "Atelier.Cauldron_DROP_IN",
+                "PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+                        "Modification": "Multiply",
+                        "Amount": 3.0
+                    },
+                    {
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/WAGgourmand.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/WAGgourmand.json
@@ -1,0 +1,3019 @@
+{
+	"Changes": [	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_almond_flour",
+				"OutputItem",
+				"wildflour.gourmetpantry_almond_flour"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_bread_flour",
+				"OutputItem",
+				"wildflour.gourmetpantry_bread_flour"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_coconut_flour",
+				"OutputItem",
+				"wildflour.gourmetpantry_coconut_flour"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_cake_flour",
+				"OutputItem",
+				"wildflour.gourmetpantry_cake_flour"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_corn_flour",
+				"OutputItem",
+				"wildflour.gourmetpantry_corn_flour"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_pastry_flour",
+				"OutputItem",
+				"wildflour.gourmetpantry_pastry_flour"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_rice_flour",
+				"OutputItem",
+				"wildflour.gourmetpantry_rice_flour"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_rainbow_sprinkles",
+				"OutputItem",
+				"wildflour.gourmetpantry_rainbow_sprinkles"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_espresso_powder",
+				"OutputItem",
+				"wildflour.gourmetpantry_espresso_powder"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_cocoa_powder",
+				"OutputItem",
+				"wildflour.gourmetpantry_cocoa_powder"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_confectioners_sugar",
+				"OutputItem",
+				"wildflour.gourmetpantry_confectioners_sugar"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_brown_sugar",
+				"OutputItem",
+				"wildflour.gourmetpantry_brown_sugar"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_pectin",
+				"OutputItem",
+				"wildflour.gourmetpantry_pectin"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenMortar",
+				"OutputRules",
+				"wildflour.gourmetpantry_chocolate_chips",
+				"OutputItem",
+				"wildflour.gourmetpantry_chocolate_chips"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	
+	//Milk	
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.gourmetpantry_almond_milk",
+				"OutputItem",
+				"wildflour.gourmetpantry_almond_milk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.gourmetpantry_cashew_milk",
+				"OutputItem",
+				"wildflour.gourmetpantry_cashew_milk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.gourmetpantry_coconut_milk",
+				"OutputItem",
+				"wildflour.gourmetpantry_coconut_milk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.gourmetpantry_hazelnut_milk",
+				"OutputItem",
+				"wildflour.gourmetpantry_hazelnut_milk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.gourmetpantry_pistachio_milk",
+				"OutputItem",
+				"wildflour.gourmetpantry_pistachio_milk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.gourmetpantry_rice_milk",
+				"OutputItem",
+				"wildflour.gourmetpantry_rice_milk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.gourmetpantry_cream",
+				"OutputItem",
+				"wildflour.gourmetpantry_cream"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_KitchenBlender",
+				"OutputRules",
+				"wildflour.gourmetpantry_buttermilk",
+				"OutputItem",
+				"wildflour.gourmetpantry_buttermilk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	
+	//Yogurt	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_ancient_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_ancient_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_blueberry_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_blueberry_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_chocolate_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_chocolate_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_cheesecake_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_cheesecake_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_vanilla_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_vanilla_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_caramel_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_caramel_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_cherry_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_cherry_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_coffee_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_coffee_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_creamsicle_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_creamsicle_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_galaxy_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_galaxy_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_custard_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_custard_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_candy_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_candy_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_tiramisu_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_tiramisu_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_macaron_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_macaron_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_mango_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_mango_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_plain_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_plain_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_orange_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_orange_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_peach_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_peach_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_mint_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_mint_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_lemon_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_lemon_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_lime_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_lime_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_pie_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_pie_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_pineapple_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_pineapple_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_pumpkin_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_pumpkin_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_shortcake_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_shortcake_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_sprinkle_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_sprinkle_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_starfruit_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_starfruit_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_sugar_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_sugar_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_gem_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_gem_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_raspberry_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_raspberry_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_strawberry_yogurt",
+				"OutputItem",
+				"wildflour.gourmetpantry_strawberry_yogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				
+				]
+			}		
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_fruit_yogurt",
+				"OutputItem",
+				"CAULDRON_CUSTOM_PRESERVE wildflour.gourmetpantry_fruit_yogurt DROP_IN_ID"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_YogurtBowl",
+				"OutputRules",
+				"wildflour.gourmetpantry_flower_yogurt",
+				"OutputItem",
+				"CAULDRON_CUSTOM_PRESERVE wildflour.gourmetpantry_flower_yogurt DROP_IN_ID"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.8
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+					"Modification": "Add",
+					"Amount": 50
+					}
+				]
+			}
+		},
+
+	//Syrup	
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_ancient_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_ancient_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_apple_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_apple_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_apricot_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_apricot_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_banana_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_banana_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_blueberry_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_blueberry_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_caramel_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_caramel_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_chai_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_chai_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_cinnamon_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_cinnamon_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_matcha_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_matcha_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_cherry_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_cherry_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_chocolate_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_chocolate_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_elderberry_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_elderberry_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_gem_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_gem_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_grenadine_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_grenadine_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_lavender_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_lavender_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_lemon_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_lemon_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_lime_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_lime_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_mango_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_mango_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_marshmallow_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_marshmallow_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_mint_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_mint_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_orange_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_orange_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_peach_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_peach_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_pineapple_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_pineapple_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_pumpkin_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_pumpkin_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_raspberry_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_raspberry_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_rose_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_rose_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_sakura_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_sakura_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_simple_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_simple_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_vanilla_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_vanilla_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_wild_strawberry_syrup",
+				"OutputItem",
+				"wildflour.gourmetpantry_wild_strawberry_syrup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_fruit_syrup",
+				"OutputItem",
+				"CAULDRON_CUSTOM_PRESERVE wildflour.gourmetpantry_fruit_syrup DROP_IN_ID"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.gourmetpantry_SyrupMaker",
+				"OutputRules",
+				"wildflour.gourmetpantry_flower_syrup",
+				"OutputItem",
+				"CAULDRON_CUSTOM_PRESERVE wildflour.gourmetpantry_flower_syrup DROP_IN_ID"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+    //Curd    
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_orange_curd",
+				"OutputItem",
+				"wildflour.gourmetpantry_orange_curd"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+	//Butter	
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_apple_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_apple_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_honey_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_honey_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_maple_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_maple_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_pumpkin_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_pumpkin_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_almond_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_almond_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_cashew_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_cashew_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_coconut_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_coconut_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_hazelnut_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_hazelnut_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_pistachio_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_pistachio_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_walnut_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_walnut_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"wildflour.gourmetpantry_MayoMachine_butter",
+				"OutputItem",
+				"wildflour.gourmetpantry_butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"wildflour.gourmetpantry_OilMaker_olive_oil",
+				"OutputItem",
+				"wildflour.gourmetpantry_olive_oil"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"wildflour.gourmetpantry_OilMaker_vanilla_extract",
+				"OutputItem",
+				"wildflour.gourmetpantry_vanilla_extract"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+	//Chocolate	
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)114",
+				"OutputRules",
+				"wildflour.gourmetpantry_Kiln_bittersweet_chocolate",
+				"OutputItem",
+				"wildflour.gourmetpantry_bittersweet_chocolate"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 1.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)114",
+				"OutputRules",
+				"wildflour.gourmetpantry_Kiln_semisweet_chocolate",
+				"OutputItem",
+				"wildflour.gourmetpantry_semisweet_chocolate"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 1.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)114",
+				"OutputRules",
+				"wildflour.gourmetpantry_Kiln_white_chocolate",
+				"OutputItem",
+				"wildflour.gourmetpantry_white_chocolate"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 1.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)16",
+				"OutputRules",
+				"wildflour.gourmetpantry_CheesePress_cream_cheese",
+				"OutputItem",
+				"wildflour.gourmetpantry_cream_cheese"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice":true,
+				"PriceModifierMode":"Stack",
+				"PriceModifiers": [
+					{
+						"Id": "wildflour.gourmetpantry_artisan_modifier",
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		}
+        
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/WAGsweets.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/WAGsweets.json
@@ -1,0 +1,1705 @@
+{
+	"Changes": [	
+		
+	//Rock Candy
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_amethyst_rock_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_amethyst_rock_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_aqua_rock_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_aqua_rock_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_emerald_rock_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_emerald_rock_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_lemon_rock_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_lemon_rock_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_rainbow_rock_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_rainbow_rock_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_ruby_rock_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_ruby_rock_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_starry_rock_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_starry_rock_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_topaz_rock_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_topaz_rock_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+	//Gourmet Pop	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_blueberry_gourmet_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_blueberry_gourmet_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_lemon_gourmet_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_lemon_gourmet_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_mint_gourmet_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_mint_gourmet_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_berry_gourmet_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_berry_gourmet_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_shortcake_gourmet_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_shortcake_gourmet_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+	//Lollipop	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_blueberry_lollipop",
+				"OutputItem",
+				"wildflour.ateliercandy_blueberry_lollipop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_cherry_lollipop",
+				"OutputItem",
+				"wildflour.ateliercandy_cherry_lollipop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_fairy_lollipop",
+				"OutputItem",
+				"wildflour.ateliercandy_fairy_lollipop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_lemon_lollipop",
+				"OutputItem",
+				"wildflour.ateliercandy_lemon_lollipop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_lime_lollipop",
+				"OutputItem",
+				"wildflour.ateliercandy_lime_lollipop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_orange_lollipop",
+				"OutputItem",
+				"wildflour.ateliercandy_orange_lollipop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_raspberry_lollipop",
+				"OutputItem",
+				"wildflour.ateliercandy_raspberry_lollipop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+	//Generic	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_flavor_lollipop",
+				"OutputItem",
+				"wildflour.ateliercandy_flavor_lollipop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_flavor_gourmet_lollipop",
+				"OutputItem",
+				"wildflour.ateliercandy_flavor_gourmet_lollipop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_SugarBoiler",
+				"OutputRules",
+				"wildflour.ateliercandy_flavor_crystal_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_flavor_crystal_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+	
+	//Candy	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_cinnamon_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_cinnamon_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_blue_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_blue_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_ginger_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_ginger_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_lime_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_lime_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_orange_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_orange_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_grape_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_grape_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_melon_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_melon_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+	//Gumballs	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_classic_gumballs",
+				"OutputItem",
+				"wildflour.ateliercandy_classic_gumballs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_grape_gumballs",
+				"OutputItem",
+				"wildflour.ateliercandy_grape_gumballs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_apple_gumballs",
+				"OutputItem",
+				"wildflour.ateliercandy_apple_gumballs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_orange_gumballs",
+				"OutputItem",
+				"wildflour.ateliercandy_orange_gumballs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_lemon_gumballs",
+				"OutputItem",
+				"wildflour.ateliercandy_lemon_gumballs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_cherry_gumballs",
+				"OutputItem",
+				"wildflour.ateliercandy_cherry_gumballs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+	//Generic	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_GumballMachine",
+				"OutputRules",
+				"wildflour.ateliercandy_flavor_hard_candy",
+				"OutputItem",
+				"wildflour.ateliercandy_flavor_hard_candy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+
+	//Mallow Pop	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_ancient_mallow_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_ancient_mallow_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_colada_mallow_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_colada_mallow_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_candy_mallow_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_candy_mallow_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_earlgrey_mallow_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_earlgrey_mallow_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_gem_mallow_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_gem_mallow_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_peach_mallow_pop",
+				"OutputItem",
+				"wildflour.ateliercandy_peach_mallow_pop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.75
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+	//Marshmallow	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_ancient_marshmallow",
+				"OutputItem",
+				"wildflour.ateliercandy_ancient_marshmallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_coconut_marshmallow",
+				"OutputItem",
+				"wildflour.ateliercandy_coconut_marshmallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_confetti_marshmallow",
+				"OutputItem",
+				"wildflour.ateliercandy_confetti_marshmallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_lavender_marshmallow",
+				"OutputItem",
+				"wildflour.ateliercandy_lavender_marshmallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_lavender_marshmallow",
+				"OutputItem",
+				"wildflour.ateliercandy_lavender_marshmallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_matcha_marshmallow",
+				"OutputItem",
+				"wildflour.ateliercandy_matcha_marshmallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_strawberry_marshmallow",
+				"OutputItem",
+				"wildflour.ateliercandy_strawberry_marshmallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_vanilla_marshmallow",
+				"OutputItem",
+				"wildflour.ateliercandy_vanilla_marshmallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+
+	//Generic	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)wildflour.ateliercandy_MarshmallowMixer",
+				"OutputRules",
+				"wildflour.ateliercandy_flavor_marshmallows",
+				"OutputItem",
+				"wildflour.ateliercandy_flavor_marshmallows"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					}
+				]
+			}
+		},
+
+	//Fairy floss	
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)17",
+				"OutputRules",
+				"wildflour.ateliercandy_Loom_classic_fairyfloss",
+				"OutputItem",
+				"wildflour.ateliercandy_classic_fairyfloss"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)17",
+				"OutputRules",
+				"wildflour.ateliercandy_Loom_lavender_fairyfloss",
+				"OutputItem",
+				"wildflour.ateliercandy_lavender_fairyfloss"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)17",
+				"OutputRules",
+				"wildflour.ateliercandy_Loom_lemon_fairyfloss",
+				"OutputItem",
+				"wildflour.ateliercandy_lemon_fairyfloss"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)17",
+				"OutputRules",
+				"wildflour.ateliercandy_Loom_orange_fairyfloss",
+				"OutputItem",
+				"wildflour.ateliercandy_orange_fairyfloss"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)17",
+				"OutputRules",
+				"wildflour.ateliercandy_Loom_mint_fairyfloss",
+				"OutputItem",
+				"wildflour.ateliercandy_mint_fairyfloss"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+					
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)17",
+				"OutputRules",
+				"wildflour.ateliercandy_Loom_strawberry_fairyfloss",
+				"OutputItem",
+				"wildflour.ateliercandy_strawberry_fairyfloss"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)17",
+				"OutputRules",
+				"wildflour.ateliercandy_Loom_vanilla_fairyfloss",
+				"OutputItem",
+				"wildflour.ateliercandy_vanilla_fairyfloss"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)17",
+				"OutputRules",
+				"wildflour.ateliercandy_Loom_flavor_fairyfloss",
+				"OutputItem",
+				"wildflour.ateliercandy_flavor_fairy_floss"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PreserveId": "Atelier.Cauldron_DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.0
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]	
+}	

--- a/[CP] Blue Eggs and Golden Mayo/compat/amanitalover.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/amanitalover.json
@@ -1,0 +1,88 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)104",
+				"OutputRules",
+				"BrownAmanitaDrying",
+				"OutputItem",
+				"BrownAmanitaDryingOutput"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)104",
+				"OutputRules",
+				"AmanitaDrying",
+				"OutputItem",
+				"AmanitaDryingOutput"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"BrownAmanitaDrying",
+				"OutputItem",
+				"BrownAmanitaDryingOutput"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"AmanitaDrying",
+				"OutputItem",
+				"AmanitaDryingOutput"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/artisanpackaging.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/artisanpackaging.json
@@ -1,0 +1,250 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)jabbic.CPArtisanPackaging_Boxer",
+				"OutputRules",
+				"Default",
+				"OutputItem",
+				"jabbic.CPArtisanPackagingBox"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyColor": true,
+                "CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Id": "Box_Multiply_Crops_By_Stack_Tiller",
+						"Condition": "PLAYER_HAS_PROFESSION Target 1, !ITEM_CONTEXT_TAG Input category_syrup, !ITEM_CONTEXT_TAG Input category_greens, !ITEM_CONTEXT_TAG Input forage_item, !ITEM_ID Input 433",
+						"Modification": "Multiply",
+						"Amount": "17.6"
+					},
+					{
+						"Id": "Box_Multiply_Crops_By_Stack_NonTiller",
+						"Condition": "!PLAYER_HAS_PROFESSION Target 1, !ITEM_CONTEXT_TAG Input category_syrup, !ITEM_CONTEXT_TAG Input category_greens, !ITEM_CONTEXT_TAG Input forage_item, !ITEM_ID Input 433",
+						"Modification": "Multiply",
+						"Amount": "16"
+					},
+					{
+						"Id": "Box_Multiply_Syrup_By_Stack_Tapper",
+						"Condition": "PLAYER_HAS_PROFESSION Target 15, ITEM_CONTEXT_TAG Input category_syrup",
+						"Modification": "Multiply",
+						"Amount": "20"
+					},
+					{
+						"Id": "Box_Multiply_Syrup_By_Stack_Tapper",
+						"Condition": "PLAYER_HAS_PROFESSION Target 15, ITEM_CONTEXT_TAG Input category_syrup",
+						"Modification": "Multiply",
+						"Amount": "20"
+					},
+					{
+						"Id": "Box_Multiply_Syrup_By_Stack_NonTapper",
+						"Condition": "!PLAYER_HAS_PROFESSION Target 15, ITEM_CONTEXT_TAG Input category_syrup",
+						"Modification": "Multiply",
+						"Amount": "16"
+					},
+					{
+						"Id": "Box_Multiply_Coffe_By_Stack",
+						"Condition": "ANY \"ITEM_CONTEXT_TAG Input category_greens\" \"ITEM_CONTEXT_TAG Input forage_item\" \"ITEM_ID Target 433\"",
+						"Modification": "Multiply",
+						"Amount": "16"
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					},
+					{
+						"Id": "Box_Add",
+						"Modification": "Add",
+						"Amount": 1000,
+						"RandomAmount": null
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)jabbic.CPArtisanPackaging_Packer",
+				"OutputRules",
+				"Default",
+				"OutputItem",
+				"jabbic.CPArtisanPackagingCrateDefault"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyColor": true,
+                "CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Id": "Crate_Multiply_Goods_By_Stack",
+						"Condition": null,
+						"Modification": "Multiply",
+						"Amount": "11"
+					},
+					{
+						"Id": "Crate_Multiply_Boxes_By_Stack",
+						"Condition": "ITEM_ID Input jabbic.CPArtisanPackaging_Box",
+						"Modification": "Multiply",
+						"Amount": "4.4"
+					},
+					{
+						"Id": "Crate_Multiply_Cans_By_Stack",
+						"Condition": "ITEM_ID Input jabbic.CPArtisanPackaging_CannedFish",
+						"Modification": "Multiply",
+						"Amount": "4.4"
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)jabbic.CPArtisanPackaging_Packer",
+				"OutputRules",
+				"Boxes",
+				"OutputItem",
+				"jabbic.CPArtisanPackagingCrateofBoxes"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyColor": true,
+                "CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Id": "Crate_Multiply_Goods_By_Stack",
+						"Condition": null,
+						"Modification": "Multiply",
+						"Amount": "4.4"
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)jabbic.CPArtisanPackaging_Packer",
+				"OutputRules",
+				"Cans",
+				"OutputItem",
+				"jabbic.CPArtisanPackagingCrateofCans"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyColor": true,
+                "CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Id": "Crate_Multiply_Goods_By_Stack",
+						"Condition": null,
+						"Modification": "Multiply",
+						"Amount": "11"
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)jabbic.CPArtisanPackaging_Canner",
+				"OutputRules",
+				"Default",
+				"OutputItem",
+				"jabbic.CPArtisanPackagingCanDefault"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyColor": true,
+                "CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Id": "Can_Double_Fish_Price_Fisher",
+						"Condition": "PLAYER_HAS_PROFESSION Target 6",
+						"Modification": "Multiply",
+						"Amount": "2.5"
+					},
+					{
+						"Id": "Can_Double_Fish_Price_Angler",
+						"Condition": "PLAYER_HAS_PROFESSION Target 8",
+						"Modification": "Multiply",
+						"Amount": "1.2"
+					},
+					{
+						"Id": "Can_Double_Fish_Price_No_Profession",
+						"Condition": "!PLAYER_HAS_PROFESSION Target 6",
+						"Modification": "Multiply",
+						"Amount": "2"
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)jabbic.CPArtisanPackaging_Canner",
+				"OutputRules",
+				"Crustaceans",
+				"OutputItem",
+				"jabbic.CPArtisanPackagingCanCrustaceans"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyColor": true,
+                "CopyPrice": true,
+				"PreserveId": "DROP_IN",
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Id": "Can_Multiply_Fish_Price",
+						"Condition": null,
+						"Modification": "Multiply",
+						"Amount": "2"
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/blueeggs.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/blueeggs.json
@@ -1,0 +1,46 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"6480.blueegg_BlueEgg",
+				"OutputItem",
+				"(O)6480.blueegg_BlueMayo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"6480.blueegg_GoldenEgg",
+				"OutputItem",
+				"(O)6480.blueegg_GoldenMayo"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/chocobovalley.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/chocobovalley.json
@@ -1,0 +1,88 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Kitsutsune.Chocobovalley_ChocoboMayonnaiseCommon",
+				"OutputItem",
+				"Kitsutsune.Chocobovalley_ChocoboMayonnaiseCommon"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Kitsutsune.Chocobovalley_ChocoboMayonnaiseUncommon",
+				"OutputItem",
+				"Kitsutsune.Chocobovalley_ChocoboMayonnaiseUncommon"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Kitsutsune.Chocobovalley_ChocoboMayonnaiseRare",
+				"OutputItem",
+				"Kitsutsune.Chocobovalley_ChocoboMayonnaiseRare"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"Kitsutsune.Chocobovalley_DriedGoldcap",
+				"OutputItem",
+				"Kitsutsune.Chocobovalley_DriedGoldcap"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		}
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/cornucopiaartisanmachines.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/cornucopiaartisanmachines.json
@@ -1,0 +1,2436 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_Alembic",
+				"OutputRules",
+				"Cornucopia_EssentialOil",
+				"OutputItem",
+				"Cornucopia_EssentialOil"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "EssentialOil",
+						"Modification": "Multiply",
+						"Amount": 7.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_ButterMilk",
+				"OutputItem",
+				"(O)Cornucopia_Butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_ButterLargeMilk",
+				"OutputItem",
+				"(O)Cornucopia_Butter"
+			],
+			"Entries": {
+				"Quality": -1,
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_ButterGoatMilk",
+				"OutputItem",
+				"(O)Cornucopia_Butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_ButterLargeGoatMilk",
+				"OutputItem",
+				"(O)Cornucopia_Butter"
+			],
+			"Entries": {
+				"Quality": -1,
+				"CopyQuality": true,
+				"MinStack": 4,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_CoconutButter",
+				"OutputItem",
+				"(O)Cornucopia_CoconutButter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_HoneyButter",
+				"OutputItem",
+				"(O)Cornucopia_HoneyButter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_SunButter",
+				"OutputItem",
+				"Cornucopia_NutButter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutButter",
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_NutButter",
+				"OutputItem",
+				"Cornucopia_NutButter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutButter",
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_ButterDefault",
+				"OutputItem",
+				"(O)Cornucopia_Butter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)16",
+				"OutputRules",
+				"Cornucopia_NutCheese_NutMilk",
+				"OutputItem",
+				"CornucopiaPineNutMilk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutCheese",
+						"Modification": "Multiply",
+						"Amount": 1.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)16",
+				"OutputRules",
+				"Cornucopia_NutCheese_NutMilk",
+				"OutputItem",
+				"CornucopiaSoyMilk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutCheese",
+						"Modification": "Multiply",
+						"Amount": 1.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)16",
+				"OutputRules",
+				"Cornucopia_NutCheese_NutMilk",
+				"OutputItem",
+				"CornucopiaOatMilk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutCheese",
+						"Modification": "Multiply",
+						"Amount": 1.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)16",
+				"OutputRules",
+				"Cornucopia_NutCheese_NutMilk",
+				"OutputItem",
+				"Default"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutCheese",
+						"Modification": "Multiply",
+						"Amount": 1.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)16",
+				"OutputRules",
+				"Cornucopia_NutCheeseDefault",
+				"OutputItem",
+				"Default"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutCheese",
+						"Modification": "Multiply",
+						"Amount": 1.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_Applesauce",
+				"OutputItem",
+				"(O)Cornucopia_Applesauce"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_ChiliPowder",
+				"OutputItem",
+				"(O)Cornucopia_ChiliPowder"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_OrangeZest",
+				"OutputItem",
+				"(O)Cornucopia_OrangeZest"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_Saffron",
+				"OutputItem",
+				"(O)Cornucopia_Saffron"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_Salt",
+				"OutputItem",
+				"(O)Cornucopia_Salt"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"Cornucopia_DriedHerb",
+				"OutputItem",
+				"(O)Cornucopia_DriedHerb"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 10
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"Cornucopia_DriedFlower",
+				"OutputItem",
+				"(O)Cornucopia_DriedFlower"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 10
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dehydrator",
+				"OutputRules",
+				"Cornucopia_DriedVegetable",
+				"OutputItem",
+				"(O)Cornucopia_DriedVegetable"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 7.5
+					},
+					{
+						"Modification": "Add",
+						"Amount": 25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_DryingRack",
+				"OutputRules",
+				"Cornucopia_DriedHerb",
+				"OutputItem",
+				"Cornucopia_DriedHerb"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 10
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_DryingRack",
+				"OutputRules",
+				"Cornucopia_DriedFlower",
+				"OutputItem",
+				"Cornucopia_DriedFlower"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 10
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_DeluxeSmoker",
+				"OutputRules",
+				"Cornucopia_RoastedGarlic",
+				"OutputItem",
+				"(O)Cornucopia_RoastedGarlic"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_DeluxeSmoker",
+				"OutputRules",
+				"Cornucopia_RoastedSunflowerSeeds",
+				"OutputItem",
+				"(O)Cornucopia_RoastedSunflowerSeeds"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_DeluxeSmoker",
+				"OutputRules",
+				"Cornucopia_RoastedPumpkinSeeds",
+				"OutputItem",
+				"(O)Cornucopia_RoastedPumpkinSeeds"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_DeluxeSmoker",
+				"OutputRules",
+				"Cornucopia_SmokedEggChickenSmall",
+				"OutputItem",
+				"(O)Cornucopia_SmokedEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_DeluxeSmoker",
+				"OutputRules",
+				"Cornucopia_SmokedEggChickenLarge",
+				"OutputItem",
+				"(O)Cornucopia_SmokedEgg"
+			],
+			"Entries": {
+				"Quality": -1,
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_DeluxeSmoker",
+				"OutputRules",
+				"Cornucopia_SmokedEggGold",
+				"OutputItem",
+				"(O)Cornucopia_SmokedEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"Quality": -1,
+				"MinStack": 5,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_DeluxeSmoker",
+				"OutputRules",
+				"Cornucopia_SmokedEgg",
+				"OutputItem",
+				"(O)Cornucopia_SmokedEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_Extruder",
+				"OutputRules",
+				"Cornucopia_Beeswax",
+				"OutputItem",
+				"(O)Cornucopia_Beeswax"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.ArtisanMachines_JuicerEnabled": true
+			},
+			"TargetField": [
+				"(BC)Cornucopia_Juicer",
+				"OutputRules",
+				"Cornucopia_Juice",
+				"OutputItem",
+				"FLAVORED_ITEM Juice DROP_IN_ID"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "Juice",
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"Cornucopia_CoconutMilk",
+				"OutputItem",
+				"(O)Cornucopia_CoconutMilk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"Cornucopia_NutMilk",
+				"OutputItem",
+				"NutMilkPineNuts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutMilk",
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"Cornucopia_NutMilk",
+				"OutputItem",
+				"Default"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutMilk",
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"Cornucopia_ChiliOil",
+				"OutputItem",
+				"(O)Cornucopia_ChiliOil"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"Cornucopia_CoconutOil",
+				"OutputItem",
+				"(O)Cornucopia_CoconutOil"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"Cornucopia_FishOil",
+				"OutputItem",
+				"(O)Cornucopia_FishOil"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_CenturyEgg",
+				"OutputItem",
+				"(O)Cornucopia_CenturyEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_FishSauce",
+				"OutputItem",
+				"(O)Cornucopia_FishSauce"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_Garum",
+				"OutputItem",
+				"(O)Cornucopia_Garum"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_PickledEggsChicken",
+				"OutputItem",
+				"(O)Cornucopia_PickledEggs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_PickledEggsChickenLarge",
+				"OutputItem",
+				"(O)Cornucopia_PickledEggs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"Quality": -1,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_PickledEggsGold",
+				"OutputItem",
+				"(O)Cornucopia_PickledEggs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"Quality": -1,
+				"MinStack": 5,
+				"MaxStack": 5,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_PickledEggs",
+				"OutputItem",
+				"(O)Cornucopia_PickledEggs"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_PickledFish",
+				"OutputItem",
+				"(O)Cornucopia_PickledFish"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Modification": "Add",
+						"Amount": 50
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_Sauerkraut",
+				"OutputItem",
+				"(O)Cornucopia_Sauerkraut"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.ArtisanMachines_VinegarKegEnabled": true
+			},
+			"TargetField": [
+				"(BC)Cornucopia_VinegarKeg",
+				"OutputRules",
+				"Cornucopia_Vinegar",
+				"OutputItem",
+				"(O)419"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.ArtisanMachines_VinegarKegEnabled": true
+			},
+			"TargetField": [
+				"(BC)Cornucopia_VinegarKeg",
+				"OutputRules",
+				"Cornucopia_VinegarUnmilledRice",
+				"OutputItem",
+				"(O)419"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_WaxBarrel",
+				"OutputRules",
+				"Cornucopia_SnackCheese",
+				"OutputItem",
+				"(O)Cornucopia_SnackCheese"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_WaxBarrel",
+				"OutputRules",
+				"Cornucopia_WaxMelts",
+				"OutputItem",
+				"Cornucopia_WaxMelts"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "WaxMelts",
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "BeeswaxBase",
+						"Modification": "Add",
+						"Amount": 250
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_WaxBarrel",
+				"OutputRules",
+				"Cornucopia_Candles",
+				"OutputItem",
+				"Cornucopia_Candles"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "Candles",
+						"Modification": "Multiply",
+						"Amount": 3
+					},
+					{
+						"Id": "BeeswaxBase",
+						"Modification": "Add",
+						"Amount": 250
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_PlainYogurtGold",
+				"OutputItem",
+				"(O)Cornucopia_PlainYogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"Quality": -1,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_PlainYogurtGoat",
+				"OutputItem",
+				"(O)Cornucopia_PlainYogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_PlainYogurtGoatGold",
+				"OutputItem",
+				"(O)Cornucopia_PlainYogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"MinStack": 4,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_PlainYogurt",
+				"OutputItem",
+				"(O)Cornucopia_PlainYogurt"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_WildHoneyYogurt",
+				"OutputItem",
+				"Cornucopia_FlavoredYogurtIridium"
+			],
+			"Entries": {
+				"Quality": 4
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_WildHoneyYogurt",
+				"OutputItem",
+				"Cornucopia_FlavoredYogurtIridium"
+			],
+			"Entries": {
+				"Quality": 4
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_WildHoneyYogurt",
+				"OutputItem",
+				"Cornucopia_FlavoredYogurtSilver"
+			],
+			"Entries": {
+				"Quality": 1
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_FlavoredHoneyYogurt",
+				"OutputItem",
+				"Cornucopia_FlavoredYogurtIridium"
+			],
+			"Entries": {
+				"Quality": 4
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_FlavoredHoneyYogurt",
+				"OutputItem",
+				"Cornucopia_FlavoredYogurtSilver"
+			],
+			"Entries": {
+				"Quality": 1
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_FlavoredYogurt",
+				"OutputItem",
+				"Cornucopia_FlavoredYogurtIridium"
+			],
+			"Entries": {
+				"Quality": 4
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_FlavoredYogurt",
+				"OutputItem",
+				"Cornucopia_FlavoredYogurtSilver"
+			],
+			"Entries": {
+				"Quality": 1
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_ChocolateYogurt",
+				"OutputItem",
+				"Cornucopia_FlavoredYogurtIridium"
+			],
+			"Entries": {
+				"Quality": 4
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_YogurtJar",
+				"OutputRules",
+				"Cornucopia_ChocolateYogurt",
+				"OutputItem",
+				"Cornucopia_FlavoredYogurtSilver"
+			],
+			"Entries": {
+				"Quality": 1
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_CocoaButter",
+				"OutputItem",
+				"(O)Cornucopia_CocoaButter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_PeanutButter",
+				"OutputItem",
+				"(O)Cornucopia_PeanutButter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_SoyButter",
+				"OutputItem",
+				"Cornucopia_NutButter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_MisoPaste",
+				"OutputItem",
+				"(O)Cornucopia_MisoPaste"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_Paprika",
+				"OutputItem",
+				"(O)Cornucopia_Paprika"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_Pepper",
+				"OutputItem",
+				"(O)Cornucopia_Pepper"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_Extruder",
+				"OutputRules",
+				"Cornucopia_Zoodles",
+				"OutputItem",
+				"(O)Cornucopia_Zoodles"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Cornucopia_Extruder",
+				"OutputRules",
+				"Cornucopia_GlassNoodles",
+				"OutputItem",
+				"(O)Cornucopia_GlassNoodles"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"Cornucopia_SoyMilk",
+				"OutputItem",
+				"(O)Cornucopia_NutMilk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutMilk",
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "InputCount",
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_GarlicMayonnaise",
+				"OutputItem",
+				"Cornucopia_GarlicMayonnaiseLargeEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_GarlicMayonnaise",
+				"OutputItem",
+				"Cornucopia_GarlicMayonnaiseSmallEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_SpicyMayonnaise",
+				"OutputItem",
+				"Cornucopia_SpicyMayonnaiseLargeEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_SpicyMayonnaise",
+				"OutputItem",
+				"Cornucopia_SpicyMayonnaiseSmallEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_TruffleMayonnaise",
+				"OutputItem",
+				"Cornucopia_TruffleMayonnaiseLargeEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_TruffleMayonnaise",
+				"OutputItem",
+				"Cornucopia_TruffleMayonnaiseSmallEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_AvocadoMayonnaise",
+				"OutputItem",
+				"Cornucopia_AvocadoMayonnaiseLargeEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_AvocadoMayonnaise",
+				"OutputItem",
+				"Cornucopia_AvocadoMayonnaiseSmallEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_BlackPepperMayonnaise",
+				"OutputItem",
+				"Cornucopia_BlackPepperMayonnaiseLargeEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_BlackPepperMayonnaise",
+				"OutputItem",
+				"Cornucopia_BlackPepperMayonnaiseSmallEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_OliveOilMayonnaise",
+				"OutputItem",
+				"Cornucopia_OliveOilMayonnaiseLargeEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_OliveOilMayonnaise",
+				"OutputItem",
+				"Cornucopia_OliveOilMayonnaiseSmallEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_WasabiMayonnaise",
+				"OutputItem",
+				"Cornucopia_WasabiMayonnaiseLargeEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_WasabiMayonnaise",
+				"OutputItem",
+				"Cornucopia_WasabiMayonnaiseSmallEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_HerbsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_DillMayonnaise",
+				"OutputItem",
+				"Cornucopia_DillMayonnaiseLargeEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"MinStack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_HerbsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"Cornucopia_DillMayonnaise",
+				"OutputItem",
+				"Cornucopia_DillMayonnaiseSmallEgg"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"Cornucopia_AvocadoOil",
+				"OutputItem",
+				"(O)Cornucopia_AvocadoOil"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_BrinedOlives",
+				"OutputItem",
+				"(O)Cornucopia_BrinedOlives"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_PickleSpears",
+				"OutputItem",
+				"(O)Cornucopia_PickleSpears"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_SoySauce",
+				"OutputItem",
+				"(O)Cornucopia_SoySauce"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_StinkyTofu",
+				"OutputItem",
+				"(O)Cornucopia_StinkyTofu"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)Cornucopia_ButterChurn",
+				"OutputRules",
+				"Cornucopia_GranolaButter",
+				"OutputItem",
+				"Cornucopia_NutButter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutButter",
+						"Modification": "Multiply",
+						"Amount": 1.5
+					},
+					{
+						"Id": "InputCount",
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"Cornucopia_OatMilk",
+				"OutputItem",
+				"(O)Cornucopia_NutMilk"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "NutMilk",
+						"Modification": "Multiply",
+						"Amount": 2.25
+					},
+					{
+						"Id": "InputCount",
+						"Modification": "Multiply",
+						"Amount": 2
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_Kimchi",
+				"OutputItem",
+				"(O)Cornucopia_Kimchi"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_Kimchi",
+				"OutputItem",
+				"Triple Output"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedTreesPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_LemonZest",
+				"OutputItem",
+				"(O)Cornucopia_LemonZest"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedTreesPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_LimeZest",
+				"OutputItem",
+				"(O)Cornucopia_LimeZest"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedTreesPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)15",
+				"OutputRules",
+				"Cornucopia_Umeboshi",
+				"OutputItem",
+				"(O)Cornucopia_Umeboshi"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_HerbsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)Cornucopia_CompactMill",
+				"OutputRules",
+				"Cornucopia_AloeGel",
+				"OutputItem",
+				"(O)Cornucopia_AloeGel"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		}
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/cornucopiamorecrops.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/cornucopiamorecrops.json
@@ -1,0 +1,235 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)16",
+				"OutputRules",
+				"Cornucopia_Tofu",
+				"OutputItem",
+				"(O)Cornucopia_Tofu"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"Cornucopia_DarkAle",
+				"OutputItem",
+				"(O)Cornucopia_DarkAle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"Cornucopia_Porter",
+				"OutputItem",
+				"(O)Cornucopia_Porter"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"Cornucopia_SparklingWine",
+				"OutputItem",
+				"(O)Cornucopia_SparklingWine"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)12",
+				"OutputRules",
+				"Cornucopia_Stout",
+				"OutputItem",
+				"(O)Cornucopia_Stout"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"Cornucopia_CanolaFlowerOil",
+				"OutputItem",
+				"(O)247"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"Cornucopia_PeanutOil",
+				"OutputItem",
+				"(O)247"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"When": {
+				"HasReadLetter |contains=Cornucopia.MoreCrops_ExtendedCropsPackEnabled": true,
+			},
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"Cornucopia_SeedsOil",
+				"OutputItem",
+				"(O)247"
+			],
+			"Entries": {
+				"StackModifiers": [
+					{
+						"Id": "DoubleQuality",
+						"Condition": "ANY \"ITEM_QUALITY Input 1 1, RANDOM 0.15\" \"ITEM_QUALITY Input 2 2, RANDOM 0.5\" \"ITEM_QUALITY Input 4 4, RANDOM 1\"",
+						"Modification": 2,
+						"Amount": 2.0,
+						"RandomAmount": null
+					}
+				],
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)19",
+				"OutputRules",
+				"Cornucopia_OliveOil",
+				"OutputItem",
+				"(O)Cornucopia_OliveOil"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/everlastingflowers.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/everlastingflowers.json
@@ -1,0 +1,2807 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingBlueJazz",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingBlueJazz"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingCrocus",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingCrocus"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingDaffodil",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingDaffodil"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+		"Action": "EditData",
+		"Target": "Data/Machines",
+		"TargetField": [
+			"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+			"OutputRules",
+			"Dora.EverlastingFlowers_EverlastingDandelion",
+			"OutputItem",
+			"Dora.EverlastingFlowers_EverlastingDandelion"
+		],
+		"Entries": {
+			"CopyQuality": true,
+			"PriceModifiers": [
+				{
+					"Id": "6480.qualitygoods",
+					"Modification": "Multiply",
+					"Amount": "{{Profit Scaling}}"
+				}
+			]
+		}
+	},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingFairyRose",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingFairyRose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingPoppy",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingPoppy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingSummerSpangle",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingSummerSpangle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingSunflower",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingSunflower"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingSweetPea",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingSweetPea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingTulip",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingTulip"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingAzureCornflower",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingAzureCornflower"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingBlueBorage",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingBlueBorage"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingBlueFlame",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingBlueFlame"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingBlueForgetMeNot",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingBlueForgetMeNot"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingButterflyLavender",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingButterflyLavender"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingGiantSnowdrop",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingGiantSnowdrop"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingGiantSpringBells",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingGiantSpringBells"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingGoldenCalendula",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingGoldenCalendula"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingLilacPansy",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingLilacPansy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingPinkClematis",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingPinkClematis"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingPinkHollyhock",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingPinkHollyhock"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingPurpleFlame",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingPurpleFlame"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingPurpleIris",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingPurpleIris"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingPurplePansy",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingPurplePansy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingSugarPlumFoxglove",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingSugarPlumFoxglove"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingTallMallow",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingTallMallow"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingWinterBlueIris",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingWinterBlueIris"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingDahlia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingDahlia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingVoidLily",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingVoidLily"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingWillowherbFlower",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingWillowherbFlower"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingSpottedOrchis",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingSpottedOrchis"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingGiantFernPlume",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingGiantFernPlume"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingLilac",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingLilac"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingAmaryllis",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingAmaryllis"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingCallaLily",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingCallaLily"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingCarnation",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingCarnation"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingDahlia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingDahlia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingDelphinium",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingDelphinium"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingFreesia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingFreesia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingFritillaria",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingFritillaria"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingIris",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingIris"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingJasmine",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingJasmine"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingLavender",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingLavender"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingLily",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingLily"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingOrchid",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingOrchid"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingPansy",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingPansy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingPeony",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingPeony"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingRose",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingRose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingSnapdragon",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingSnapdragon"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingStripedSquill",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingStripedSquill"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingZinnia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingZinnia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingAlamanda",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingAlamanda"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingGardenia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingGardenia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingHibiscus",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingHibiscus"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_QLEverlastingLilac",
+				"OutputItem",
+				"Dora.EverlastingFlowers_QLEverlastingLilac"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingBlueMist",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingBlueMist"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingChrysanthemum",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingChrysanthemum"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingIris",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingIris"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLily",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLily"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLotus",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLotus"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingMorningGlory",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingMorningGlory"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingOrchid",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingOrchid"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPansy",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPansy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPinkCat",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPinkCat"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingRose",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingRose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingBeeBalm",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingBeeBalm"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingBluebonnet",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingBluebonnet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingButtercup",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingButtercup"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingCalicoRose",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingCalicoRose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingCamellia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingCamellia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingCarnation",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingCarnation"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingChamomile",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingChamomile"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingClarySage",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingClarySage"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingClematis",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingClematis"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingDahlia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingDahlia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingDaisy",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingDaisy"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingFairyDuster",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingFairyDuster"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingFreesia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingFreesia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingGeranium",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingGeranium"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingHoneysuckle",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingHoneysuckle"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingHyacinth",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingHyacinth"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingHydrangea",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingHydrangea"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLarkspur",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLarkspur"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLavender",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLavender"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLilac",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLilac"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLupine",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingLupine"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPeony",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPeony"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPetunia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPetunia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPitcherPlant",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPitcherPlant"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPurpleConeflower",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPurpleConeflower"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingRafflesia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingRafflesia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingSpringRose",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingSpringRose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingSummerRose",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingSummerRose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingFallRose",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingFallRose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingWinterRose",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingWinterRose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPrismaticRose",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingPrismaticRose"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingViolet",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingViolet"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingWolfsbane",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingWolfsbane"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingHibiscus",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingHibiscus"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingJasmine",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingJasmine"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingMagnolia",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingMagnolia"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingWisteria",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingWisteria"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingYlangYlang",
+				"OutputItem",
+				"Dora.EverlastingFlowers_CornucopiaEverlastingYlangYlang"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)Dora.EverlastingFlowers_EnchantedCrystal",
+				"OutputRules",
+				"Dora.EverlastingFlowers_EverlastingFlower",
+				"OutputItem",
+				"Dora.EverlastingFlowers_EverlastingFlower"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"CopyPrice": true,
+				"PriceModifierMode": "Stack",
+				"PriceModifiers": [
+					{
+						"Modification": "Multiply",
+						"Amount": 2.5
+					},
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/ilucieEmu.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/ilucieEmu.json
@@ -1,0 +1,46 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"EmuMayonnaise",
+				"OutputItem",
+				"(O)EmuMayonnaise"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"GoldenEmuMayonnaise",
+				"OutputItem",
+				"(O)GoldenEmuMayonnaise"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/radm.milkdasheep.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/radm.milkdasheep.json
@@ -1,0 +1,47 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)16",
+				"OutputRules",
+				"radm.milkdasheep_SheepMilk",
+				"OutputItem",
+				"(O)radm.milkdasheep_SheepCheese"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+        {
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)16",
+				"OutputRules",
+				"radm.milkdasheep_LargeSheepMilk",
+				"OutputItem",
+				"(O)radm.milkdasheep_SheepCheese"
+			],
+			"Entries": {
+				"CopyQuality": true,
+                "Minstack": 2,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/compat/resourcechickens.json
+++ b/[CP] Blue Eggs and Golden Mayo/compat/resourcechickens.json
@@ -1,0 +1,46 @@
+{
+	"Changes": [
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"UncleArya.ResourceChickens.ResourceEggs",
+				"OutputItem",
+				"(O)306"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+		{
+			"Action": "EditData",
+			"Target": "Data/Machines",
+			"TargetField": [
+				"(BC)24",
+				"OutputRules",
+				"UncleArya.ResourceChickens.LargeResourceEggs",
+				"OutputItem",
+				"(O)306"
+			],
+			"Entries": {
+				"CopyQuality": true,
+				"PriceModifiers": [
+					{
+						"Id": "6480.qualitygoods",
+						"Modification": "Multiply",
+						"Amount": "{{Profit Scaling}}"
+					}
+				]
+			}
+		},
+	]
+}

--- a/[CP] Blue Eggs and Golden Mayo/content.json
+++ b/[CP] Blue Eggs and Golden Mayo/content.json
@@ -1,158 +1,75 @@
 {
 	"Format": "2.0",
 	"ConfigSchema": {
-		"Blue Mayo": {
-			"AllowValues": "true, false",
-			"Default": "true",
-			"Description": "Allows processing blue eggs into blue mayo. When false, blue eggs make normal mayo."
+		"Profit Scaling": {
+			"AllowValues": "1, 0.9, 0.8, 0.75, 0.7",
+			"Default": "0.7",
+			"Description": "Set the balance for your artisan machines. 0.7x makes it equal to the average profit you would make in vanilla, while 1x strictly copies quality without any price changes (giving you much higher profit)."
 		},
-		"Golden Mayo": {
+		"Large Animal Items": {
 			"AllowValues": "true, false",
 			"Default": "true",
-			"Description": "Allows processing golden eggs into golden mayo."
-		},
-		"Ostrich Mayo": {
-			"AllowValues": "true, false",
-			"Default": "true",
-			"Description": "Allows processing ostrich eggs into ostrich mayo."
+			"Description": "Choose whether large milks and large eggs should make large versions of their artisan product. If set to false, these will produce 2x the amount of normal cheese and mayo."
 		}
 	},
 	"Changes": [
 		{
 			"LogName": "Load textures",
 			"Action": "Load",
-			"Target": "6480.blueegg/Objects",
+			"Target": "6480.qualitygoods/Objects",
 			"FromFile": "assets/objects.png"
 		},
 		{
-			"LogName": "Modify blue chicken produce entry",
-			"Action": "EditData",
-			"Target": "Data/FarmAnimals",
-			"Fields": {
-				"Blue Chicken": {
-					"EggItemIds": [
-						"6480.blueegg_BlueEgg",
-						"176",
-						"174"
-					],
-					"ProduceItemIds": [
-						{
-							"ItemId": "6480.blueegg_BlueEgg"
-						}
-					],
-					"DeluxeProduceItemIds": [
-						{
-							"ItemId": "6480.blueegg_BlueEgg"
-						}
-					]
-				}
-			}
-		},
-		{
-			"LogName": "Add new items",
-			"Action": "EditData",
-			"Target": "Data/Objects",
-			"Entries": {
-				"6480.blueegg_BlueEgg": {
-					"Name": "6480.blueegg_BlueEgg",
-					"Type": "Basic",
-					"Category": -5,
-					"SpriteIndex": 0,
-					"DisplayName": "{{i18n:BlueEgg_Name}}",
-					"Description": "{{i18n:BlueEgg_description}}",
-					"Texture": "6480.blueegg/Objects",
-					"Price": 100,
-					"Edibility": 10,
-					"ContextTags": [
-						"egg_item",
-						"color_blue"
-					]
-				}
-			}
-		},
-		{
 			"LogName": "Add new items",
 			"Action": "EditData",
 			"Target": "Data/Objects",
 			"When": {
-				"Blue Mayo": true
+				"Large Animal Items": true
 			},
 			"Entries": {
-				"6480.blueegg_BlueMayo": {
-					"Name": "6480.blueegg_BlueMayo",
+				"6480.qualitygoods_LargeCheese": {
+					"Name": "6480.qualitygoods_LargeCheese",
+					"Type": "Basic",
+					"Category": -26,
+					"SpriteIndex": 0,
+					"DisplayName": "{{i18n:LargeCheese_name}}",
+					"Description": "{{i18n:LargeCheese_description}}",
+					"Texture": "6480.qualitygoods/Objects",
+					"Price": 345,
+					"Edibility": 100,
+					"ContextTags": [
+						"color_yellow",
+						"cheese_item"
+					]
+				},
+				"6480.qualitygoods_LargeGoatCheese": {
+					"Name": "6480.qualitygoods_LargeGoatCheese",
 					"Type": "Basic",
 					"Category": -26,
 					"SpriteIndex": 1,
-					"DisplayName": "{{i18n:BlueMayo_Name}}",
-					"Description": "{{i18n:BlueMayo_description}}",
-					"Texture": "6480.blueegg/Objects",
-					"Price": 285,
-					"Edibility": 20,
-					"IsDrink": true,
+					"DisplayName": "{{i18n:LargeGoatCheese_name}}",
+					"Description": "{{i18n:LargeGoatCheese_description}}",
+					"Texture": "6480.qualitygoods/Objects",
+					"Price": 600,
+					"Edibility": 100,
 					"ContextTags": [
-						"color_blue",
-						"mayo_item"
+						"color_yellow",
+						"cheese_item"
 					]
-				}
-			}
-		},
-		{
-			"Action": "EditData",
-			"Target": "Data/NPCGiftTastes",
-			"TextOperations": [
-				{
-					"Operation": "Append",
-					"Target": [
-						"Fields",
-						"Shane",
-						1
-					],
-					"Value": "6480.blueegg_BlueEgg",
-					"Delimiter": " "
-				}
-			]
-		},
-		{
-			"Action": "EditData",
-			"Target": "Data/NPCGiftTastes",
-			"When": {
-				"Blue Mayo": true
-			},
-			"TextOperations": [
-				{
-					"Operation": "Append",
-					"Target": [
-						"Fields",
-						"Shane",
-						1
-					],
-					"Value": "6480.blueegg_BlueMayo",
-					"Delimiter": " "
-				}
-			]
-		},
-		{
-			"LogName": "Add new items",
-			"Action": "EditData",
-			"Target": "Data/Objects",
-			"When": {
-				"Golden Mayo": true
-			},
-			"Entries": {
-				"6480.blueegg_GoldenMayo": {
-					"Name": "6480.blueegg_GoldenMayo",
+				},
+				"6480.qualitygoods_LargeMayo": {
+					"Name": "6480.qualitygoods_LargeMayo",
 					"Type": "Basic",
 					"Category": -26,
 					"SpriteIndex": 2,
-					"DisplayName": "{{i18n:GoldenMayo_Name}}",
-					"Description": "{{i18n:GoldenMayo_description}}",
-					"Texture": "6480.blueegg/Objects",
-					"Price": 855,
+					"DisplayName": "{{i18n:LargeMayo_name}}",
+					"Description": "{{i18n:LargeMayo_description}}",
+					"Texture": "6480.qualitygoods/Objects",
+					"Price": 285,
 					"Edibility": 40,
 					"IsDrink": true,
-					"ExcludeFromShippingCollection": true,
 					"ContextTags": [
-						"color_yellow",
+						"color_white",
 						"mayo_item"
 					]
 				}
@@ -161,140 +78,154 @@
 		{
 			"LogName": "Add new items",
 			"Action": "EditData",
-			"Target": "Data/Objects",
+			"Target": "Data/CookingRecipes",
 			"When": {
-				"Ostrich Mayo": true
+				"Large Animal Items": true
 			},
 			"Entries": {
-				"6480.blueegg_OstrichMayo": {
-					"Name": "6480.blueegg_OstrichMayo",
-					"Type": "Basic",
-					"Category": -26,
-					"SpriteIndex": 3,
-					"DisplayName": "{{i18n:OstrichMayo_Name}}",
-					"Description": "{{i18n:OstrichMayo_description}}",
-					"Texture": "6480.blueegg/Objects",
-					"Price": 1900,
-					"Edibility": 100,
-					"IsDrink": true,
-					"ContextTags": [
-						"color_pink",
-						"mayo_item"
-					]
-				}
+				"Cheese": "6480.qualitygoods_LargeCheese 1/1 10/424 2/Farming 3",
+				"Goat Cheese": "6480.qualitygoods_LargeGoatCheese 1/1 10/426 2/Farming 3",
+				"Mayonnaise": "6480.qualitygoods_LargeMayo 1/1 10/306 2/Farming 3"
 			}
 		},
 		{
-			"LogName": "Modify mayonnaise machine rules (Blue Mayo)",
-			"Action": "EditData",
-			"Target": "Data/Machines",
-			"When": {
-				"Blue Mayo": true
-			},
-			"TargetField": [
-				"(BC)24",
-				"OutputRules"
-			],
-			"Entries": {
-				"6480.blueegg_BlueEgg": {
-					"Id": "6480.blueegg_BlueEgg",
-					"Triggers": [
-						{
-							"Trigger": "ItemPlacedInMachine",
-							"RequiredItemId": "(O)6480.blueegg_BlueEgg",
-							"RequiredCount": 1
-						}
-					],
-					"OutputItem": [
-						{
-							"Id": "(O)6480.blueegg_BlueMayo",
-							"ItemId": "(O)6480.blueegg_BlueMayo"
-						}
-					],
-					"MinutesUntilReady": 180
-				}
-			},
-			"MoveEntries": [
-				{
-					"Id": "6480.blueegg_BlueEgg",
-					"ToPosition": "Top"
-				}
-			]
+			"Action": "Include",
+			"FromFile": "data/cheesepress.json, data/keg.json, data/mayomachine.json, data/preservesjar.json, data/oilmaker.json, data/dehydrator.json"
 		},
 		{
-			"LogName": "Modify mayonnaise machine rules (Golden Mayo)",
-			"Action": "EditData",
-			"Target": "Data/Machines",
+			"Action": "Include",
+			"FromFile": "compat/blueeggs.json",
 			"When": {
-				"Golden Mayo": true
-			},
-			"TargetField": [
-				"(BC)24",
-				"OutputRules"
-			],
-			"Entries": {
-				"6480.blueegg_GoldenEgg": {
-					"Id": "6480.blueegg_GoldenEgg",
-					"Triggers": [
-						{
-							"Trigger": "ItemPlacedInMachine",
-							"RequiredItemId": "(O)928",
-							"RequiredCount": 1
-						}
-					],
-					"OutputItem": [
-						{
-							"Id": "(O)6480.blueegg_GoldenMayo",
-							"ItemId": "(O)6480.blueegg_GoldenMayo"
-						}
-					],
-					"MinutesUntilReady": 180
-				}
-			},
-			"MoveEntries": [
-				{
-					"Id": "6480.blueegg_GoldenEgg",
-					"ToPosition": "Top"
-				}
-			]
+				"HasMod|contains = 6480.blueegg": true
+			}
 		},
 		{
-			"LogName": "Modify mayonnaise machine rules",
-			"Action": "EditData",
-			"Target": "Data/Machines",
+			"Action": "Include",
+			"FromFile": "compat/cornucopiamorecrops.json",
 			"When": {
-				"Ostrich Mayo": true
-			},
-			"TargetField": [
-				"(BC)24",
-				"OutputRules"
-			],
-			"Entries": {
-				"6480.blueegg_OstrichEgg": {
-					"Id": "6480.blueegg_OstrichEgg",
-					"Triggers": [
-						{
-							"Trigger": "ItemPlacedInMachine",
-							"RequiredItemId": "(O)289",
-							"RequiredCount": 1
-						}
-					],
-					"OutputItem": [
-						{
-							"Id": "(O)6480.blueegg_OstrichMayo",
-							"ItemId": "(O)6480.blueegg_OstrichMayo",
-							"CopyQuality": true
-						}
-					],
-					"MinutesUntilReady": 180
-				}
-			},
-			"MoveEntries": [
-				{
-					"Id": "6480.blueegg_OstrichEgg",
-					"ToPosition": "Top"
-				}
-			]
-		}
+				"HasMod|contains = Cornucopia.MoreCrops": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/CornucopiaartisanMachines.json",
+			"When": {
+				"HasMod|contains = Cornucopia.ArtisanMachines": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/chocobovalley.json",
+			"When": {
+				"HasMod|contains = Kitsutsune.Chocobovalley": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/resourcechickens.json",
+			"When": {
+				"HasMod|contains = UncleArya.ResourceChickens": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/ilucieEmu.json",
+			"When": {
+				"HasMod|contains = ilucie.EmuBarnAnimal": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/AlazdrielQuails.json",
+			"When": {
+				"HasMod|contains = Alazdriel.Quails": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/Meara.Roosters.json",
+			"When": {
+				"HasMod|contains = Meara.Roosters": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/artisanpackaging.json",
+			"When": {
+				"HasMod|contains = jabbic.CPArtisanPackaging": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/everlastingflowers.json",
+			"When": {
+				"HasMod|contains = Dora.EverlastingFlowers": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/WAGgourmand.json",
+			"When": {
+				"HasMod|contains = wildflour.gourmetpantry": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/WAGbarista(cold).json",
+			"When": {
+				"HasMod|contains = wildflour.atelierjuicebar": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/WAGbarista(hot).json",
+			"When": {
+				"HasMod|contains = wildflour.atelierbarista": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/WAGbrewer.json",
+			"When": {
+				"HasMod|contains = wildflour.alesxmeads": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/WAGfrozengoods.json",
+			"When": {
+				"HasMod|contains = wildflour.atelierfrozen": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/WAGsweets.json",
+			"When": {
+				"HasMod|contains = wildflour.ateliercandy": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/WAGflorist.json",
+			"When": {
+				"HasMod|contains = wildflour.atelierfloral": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/HXWfreshlybaked.json",
+			"When": {
+				"HasMod|contains = HXW.FreshlyBaked": true,
+				"HasMod|contains = Atelier.Cauldron": true
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "compat/radm.milkdasheep.json",
+			"When": {
+				"HasMod|contains = radm.milkdasheep": true
+			}
+		},
+		
 	]
 }

--- a/[CP] Blue Eggs and Golden Mayo/manifest.json
+++ b/[CP] Blue Eggs and Golden Mayo/manifest.json
@@ -1,14 +1,105 @@
 {
-	"Name": "[CP] Blue Eggs and Golden Mayo",
+	"Name": "[CP] Yet Another (Balanced) Quality Goods Mod",
 	"Author": "6480",
-	"Version": "1.1.2",
-	"Description": "Adds a special blue egg that can be turned into blue mayo. Adds golden and ostrich mayos.",
-	"UniqueID": "6480.blueegg",
-	"MinimumGameVersion": "1.6.0",
-	"UpdateKeys": [
-		"Nexus: 20266"
-	],
+	"Version": "1.1.0",
+	"MinimumApiVersion": "4.0.0",
+	"Description": "Makes artisan goods keep the quality of the input item, with optional configuration for profit balance.",
+	"UniqueID": "6480.qualitygoods",
+	"UpdateKeys": [ "Nexus: 23386" ],
 	"ContentPackFor": {
-		"UniqueID": "Pathoschild.ContentPatcher"
-	}
+		"UniqueID": "Pathoschild.ContentPatcher",
+		"MinimumVersion": "2.0.0"
+	},
+	"Dependencies": [
+		{
+			"UniqueID": "Atelier.Cauldron",
+			"IsRequired": false
+			
+		},
+		{
+			"UniqueID": "6480.blueegg",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "Cornucopia.MoreCrops",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "Cornucopia.ArtisanMachines",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "Kitsutsune.Chocobovalley",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "UncleArya.ResourceChickens",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "ilucie.EmuBarnAnimal",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "Alazdriel.Quails",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "Meara.Roosters",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "jabbic.CPArtisanPackaging",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "Dora.EverlastingFlowers",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "wildflour.gourmetpantry",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "wildflour.atelierjuicebar",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "wildflour.atelierbarista",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "wildflour.alesxmeads",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "wildflour.atelierfrozen",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "wildflour.ateliercandy",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "wildflour.atelierfloral",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "HXW.FreshlyBaked",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "Aimon111.AmanitaLover",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "radm.milkdasheep",
+			"IsRequired": false
+		},
+		{
+			"UniqueID": "DaLion.Professions",
+			"IsRequired": false
+		},
+
+	]
 }


### PR DESCRIPTION
Adds compalitiblity for the following mods:
- CP - Quails for Sharkles by Alazdriel
- (CP) Artisan Packaging by JabbicEverlasting
- Everlasting Flowers by Doragoun
- HxW Freshly Baked by HimeTarts and wildflourmods
- Ilucie's Emu (for 1.6) by Ilucie
- Content Patcher Roosters For 1.6 by Mearakat
- Milkable Sheep by radmaninoff
- Resource Chickens by UncleArya and Tophatta
- Wildflour's Atelier Goods - Barista (Cold) by wildflourmods
- Wildflour's Atelier Goods - Barista (Hot) by wildflourmods
- Wildflour's Atelier Goods - Brewer by wildflourmods
- Wildflour's Atelier Goods - Florist by wildflourmods
- Wildflour's Atelier Goods - Confectioner (Frozen) by wildflourmods
- Wildflour's Atelier Goods - Confectioner (Sweet) by wildflourmods
- Wildflour's Atelier Goods - Gourmand by wildflourmods
- Chocobo Valley - Custom livestock crops and more by kitsutsune

Also Adjusts the content.json and manifest.json accordingly.